### PR TITLE
Improve variable handling and initialization

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -25,14 +25,14 @@ class ExecutionEngine:
     Sépare data graph (DAG) et exec graph (événements).
     Hooks pour visualisation (on_node_start/finish, on_edge_fired).
     """
-    def __init__(self, nodes: List[NodeSpec], edges: List[EdgeSpec], hooks: Optional[object] = None):
+    def __init__(self, nodes: List[NodeSpec], edges: List[EdgeSpec], hooks: Optional[object] = None, vars_init: Optional[Dict[str, Any]] = None):
         self.nodes = {n.id: n for n in nodes}
         self.edges = edges
         self.instances = {}
         self.results: Dict[str, Dict[str, Any]] = {}
         self.hooks = hooks
         self._cancelled = False
-        self.vars: Dict[str, Any] = {}
+        self.vars: Dict[str, Any] = dict(vars_init or {})
 
         self.data_incoming: Dict[Tuple[str, str], Tuple[str, str]] = {}
         self.exec_outgoing: DefaultDict[Tuple[str, str], List[Tuple[str, str]]] = defaultdict(list)

--- a/app/core/engine_async.py
+++ b/app/core/engine_async.py
@@ -19,12 +19,12 @@ class EngineWorker(QtCore.QObject):
     sigNodeOutput = QtCore.pyqtSignal(str, dict)
     sigError = QtCore.pyqtSignal(str)
 
-    @QtCore.pyqtSlot(list, list)
-    def start_run(self, nodes, edges):
+    @QtCore.pyqtSlot(list, list, dict)
+    def start_run(self, nodes, edges, vars_init):
         try:
             self.sigRunStarted.emit()
             hooks = _HooksBridge(self)
-            self._engine = ExecutionEngine(nodes, edges, hooks=hooks)
+            self._engine = ExecutionEngine(nodes, edges, hooks=hooks, vars_init=vars_init)
             results = self._engine.run()
             self.sigRunFinished.emit(results)
             self._engine = None
@@ -62,9 +62,9 @@ class EngineRunner(QtCore.QObject):
         self._worker.sigError.connect(self.sigError)
         self._thread.start()
 
-    def start(self, nodes, edges):
+    def start(self, nodes, edges, vars_init=None):
         QtCore.QMetaObject.invokeMethod(self._worker, "start_run", QtCore.Qt.QueuedConnection,
-                                        QtCore.Q_ARG(list, nodes), QtCore.Q_ARG(list, edges))
+                                        QtCore.Q_ARG(list, nodes), QtCore.Q_ARG(list, edges), QtCore.Q_ARG(dict, vars_init or {}))
 
     def stop(self):
         self._worker.cancel()

--- a/app/ui/variables_panel.py
+++ b/app/ui/variables_panel.py
@@ -4,13 +4,27 @@ from PyQt5 import QtWidgets, QtCore
 _TYPES = ['String', 'Int', 'Float', 'Bool']
 
 
+def _cast(val: str, tname: str) -> str:
+    typemap = {'String': str, 'Int': int, 'Float': float, 'Bool': bool}
+    typ = typemap.get(tname, str)
+    try:
+        if typ is bool:
+            if isinstance(val, str):
+                return str(val).lower() in ('1', 'true', 'yes', 'on')
+            return bool(val)
+        return typ(val)
+    except Exception:
+        return typ()
+
+
 class VariablesPanel(QtWidgets.QWidget):
     addGetRequested = QtCore.pyqtSignal(str, str)  # (name, type)
     addSetRequested = QtCore.pyqtSignal(str, str)
     variableRenamed = QtCore.pyqtSignal(str, str, str)  # old_name, new_name, type
     variableTypeChanged = QtCore.pyqtSignal(str, str, str)  # name, old_type, new_type
     variableRemoved = QtCore.pyqtSignal(str, str)  # name, type
-    variableAdded = QtCore.pyqtSignal(str, str)  # name, type
+    variableAdded = QtCore.pyqtSignal(str, str, str)  # name, type, init_value
+    variableInitChanged = QtCore.pyqtSignal(str, str)  # name, new_init_value
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -25,12 +39,13 @@ class VariablesPanel(QtWidgets.QWidget):
         layout.addWidget(tb)
 
         # Table with action buttons column
-        self.table = QtWidgets.QTableWidget(0, 3, self)
-        self.table.setHorizontalHeaderLabels(['Name', 'Type', ''])
+        self.table = QtWidgets.QTableWidget(0, 4, self)
+        self.table.setHorizontalHeaderLabels(['Name', 'Type', 'Init Value', ''])
         self.table.horizontalHeader().setStretchLastSection(False)
         self.table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
         self.table.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
         self.table.horizontalHeader().setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeToContents)
         self.table.verticalHeader().setVisible(False)
         self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.DoubleClicked | QtWidgets.QAbstractItemView.SelectedClicked)
@@ -51,10 +66,12 @@ class VariablesPanel(QtWidgets.QWidget):
         for r in range(self.table.rowCount()):
             name_item = self.table.item(r, 0)
             combo = self.table.cellWidget(r, 1)
+            init_item = self.table.item(r, 2)
             name = name_item.text().strip() if name_item else ''
             t = combo.currentText() if combo else 'String'
+            init_val = init_item.text().strip() if init_item else ''
             if name:
-                out.append((name, t))
+                out.append((name, t, init_val))
         return out
 
     def _row_from_widget(self, w: QtWidgets.QWidget) -> int:
@@ -63,7 +80,7 @@ class VariablesPanel(QtWidgets.QWidget):
             widget = widget.parent()  # cell widget container
         return self.table.indexAt(widget.pos()).row()
 
-    def _add_row(self, name: str = '', t: str = 'String'):
+    def _add_row(self, name: str = '', t: str = 'String', init: str = ''):
         r = self.table.rowCount()
         self.table.insertRow(r)
         name_item = QtWidgets.QTableWidgetItem(name)
@@ -75,6 +92,10 @@ class VariablesPanel(QtWidgets.QWidget):
         combo.currentTextChanged.connect(lambda nt, c=combo: self._on_type_changed(c, nt))
         self.table.setCellWidget(r, 1, combo)
 
+        init_val = str(_cast(init, t))
+        init_item = QtWidgets.QTableWidgetItem(init_val)
+        self.table.setItem(r, 2, init_item)
+
         # action buttons
         w = QtWidgets.QWidget()
         lay = QtWidgets.QHBoxLayout(w)
@@ -85,9 +106,9 @@ class VariablesPanel(QtWidgets.QWidget):
         lay.addWidget(bget); lay.addWidget(bset)
         bget.clicked.connect(lambda _, b=bget: self._on_add_get(b))
         bset.clicked.connect(lambda _, b=bset: self._on_add_set(b))
-        self.table.setCellWidget(r, 2, w)
+        self.table.setCellWidget(r, 3, w)
 
-        self._var_data[r] = (name, t)
+        self._var_data[r] = (name, t, init_val)
 
     def _remove_selected(self):
         rows = sorted({i.row() for i in self.table.selectedIndexes()}, reverse=True)
@@ -102,30 +123,41 @@ class VariablesPanel(QtWidgets.QWidget):
         self._rebuild_var_data()
 
     def _on_item_changed(self, item: QtWidgets.QTableWidgetItem):
-        if item.column() != 0:
-            return
         r = item.row()
-        old_name, old_type = self._var_data.get(r, ('', 'String'))
-        new_name = item.text().strip()
+        name_item = self.table.item(r, 0)
         combo = self.table.cellWidget(r, 1)
+        init_item = self.table.item(r, 2)
+        name = name_item.text().strip() if name_item else ''
         t = combo.currentText() if combo else 'String'
-        if not old_name and new_name:
-            self.variableAdded.emit(new_name, t)
-        elif old_name != new_name:
-            self.variableRenamed.emit(old_name, new_name, t)
-        self._var_data[r] = (new_name, t)
+        init_val = init_item.text().strip() if init_item else ''
+        old_name, old_type, old_val = self._var_data.get(r, ('', 'String', ''))
+
+        if item.column() == 0:
+            if not old_name and name:
+                self.variableAdded.emit(name, t, init_val)
+            elif old_name != name:
+                self.variableRenamed.emit(old_name, name, t)
+        elif item.column() == 2:
+            self.variableInitChanged.emit(name, init_val)
+
+        self._var_data[r] = (name, t, init_val)
 
     def _on_type_changed(self, combo: QtWidgets.QComboBox, new_t: str):
         r = self._row_from_widget(combo)
         name_item = self.table.item(r, 0)
+        init_item = self.table.item(r, 2)
         name = name_item.text().strip() if name_item else ''
-        old_name, old_type = self._var_data.get(r, ('', 'String'))
+        old_name, old_type, old_val = self._var_data.get(r, ('', 'String', ''))
+        casted = str(_cast(init_item.text() if init_item else '', new_t)) if init_item else ''
+        if init_item:
+            init_item.setText(casted)
         if name:
             if not old_name and name:
-                self.variableAdded.emit(name, new_t)
+                self.variableAdded.emit(name, new_t, casted)
             elif old_type != new_t:
                 self.variableTypeChanged.emit(name, old_type, new_t)
-        self._var_data[r] = (name, new_t)
+                self.variableInitChanged.emit(name, casted)
+        self._var_data[r] = (name, new_t, casted)
 
     def _on_add_get(self, btn: QtWidgets.QToolButton):
         r = self._row_from_widget(btn)
@@ -150,9 +182,11 @@ class VariablesPanel(QtWidgets.QWidget):
         for r in range(self.table.rowCount()):
             name_item = self.table.item(r, 0)
             combo = self.table.cellWidget(r, 1)
+            init_item = self.table.item(r, 2)
             name = name_item.text().strip() if name_item else ''
             t = combo.currentText() if combo else 'String'
-            self._var_data[r] = (name, t)
+            init_val = init_item.text().strip() if init_item else ''
+            self._var_data[r] = (name, t, init_val)
 
     def _menu(self, gpos):
         idx = self.table.indexAt(gpos)


### PR DESCRIPTION
## Summary
- Add initial value column and related signals for variables
- Make GetVariable nodes read-only and drop invalid links on type change
- Allow execution engine to receive initial variable values

## Testing
- `python -m py_compile ui/variables_panel.py ui/main_window.py core/engine.py core/engine_async.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a075b3d6a8832dab470d954ec96c5c