### PR TITLE
Add const nodes and improve type compatibility

### DIFF
--- a/app/nodes/__init__.py
+++ b/app/nodes/__init__.py
@@ -5,4 +5,4 @@ try:
     from . import serial  # noqa: F401
 except Exception:
     pass
-from . import variables_runtime  # noqa: F401
+from . import variables_runtime, constants  # noqa: F401

--- a/app/nodes/constants.py
+++ b/app/nodes/constants.py
@@ -1,0 +1,97 @@
+from typing import Dict, Any
+from .base import BaseNode
+from ..core.registry import registry
+
+
+@registry.register
+class ConstInt(BaseNode):
+    CATEGORY = "Variables"
+    COLOR = "#E06C75"
+
+    @classmethod
+    def title(cls) -> str:
+        return "Const Int"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ConstInt"
+
+    @classmethod
+    def outputs(cls) -> Dict[str, type]:
+        return {"value": int}
+
+    def process(self, **kwargs) -> Dict[str, Any]:
+        val = self._params.get("value", 0)
+        try:
+            val = int(val)
+        except Exception:
+            val = 0
+        return {"value": val}
+
+
+@registry.register
+class ConstFloat(BaseNode):
+    CATEGORY = "Variables"
+    COLOR = "#2BB1FF"
+
+    @classmethod
+    def title(cls) -> str:
+        return "Const Float"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ConstFloat"
+
+    @classmethod
+    def outputs(cls) -> Dict[str, type]:
+        return {"value": float}
+
+    def process(self, **kwargs) -> Dict[str, Any]:
+        val = self._params.get("value", 0.0)
+        try:
+            val = float(val)
+        except Exception:
+            val = 0.0
+        return {"value": val}
+
+
+@registry.register
+class ConstBool(BaseNode):
+    CATEGORY = "Variables"
+    COLOR = "#98C379"
+
+    @classmethod
+    def title(cls) -> str:
+        return "Const Bool"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ConstBool"
+
+    @classmethod
+    def outputs(cls) -> Dict[str, type]:
+        return {"value": bool}
+
+    def process(self, **kwargs) -> Dict[str, Any]:
+        return {"value": bool(self._params.get("value", False))}
+
+
+@registry.register
+class ConstString(BaseNode):
+    CATEGORY = "Variables"
+    COLOR = "#C678DD"
+
+    @classmethod
+    def title(cls) -> str:
+        return "Const String"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "ConstString"
+
+    @classmethod
+    def outputs(cls) -> Dict[str, type]:
+        return {"value": str}
+
+    def process(self, **kwargs) -> Dict[str, Any]:
+        return {"value": str(self._params.get("value", ""))}

--- a/app/ui/graph.py
+++ b/app/ui/graph.py
@@ -23,7 +23,13 @@ EXEC_COLOR = QtGui.QColor("#FFFFFF")
 FLOW_COLOR = QtGui.QColor("#FF9A00")
 
 def is_compatible(src_t, dst_t) -> bool:
-    return src_t == dst_t
+    """Return True if two port types can be connected.
+
+    Besides strict equality, allow the generic ``object`` type to act as a
+    wildcard so that generic ports (e.g. variable nodes) can connect to any
+    specific data type.
+    """
+    return src_t == dst_t or src_t is object or dst_t is object
 
 PORT_RADIUS = 6
 EXEC_PORT_RADIUS = 7
@@ -301,8 +307,12 @@ class NodeItem(QtWidgets.QGraphicsObject):
 
         node_cls = registry.types()[type_name]
         title = node_cls.title()
+
+        color_attr = getattr(node_cls, 'COLOR', None) or getattr(node_cls, 'color', None)
         if getattr(node_cls, 'event_node', False):
             self.header.setBrush(QtGui.QBrush(QtGui.QColor('#C0392B')))
+        elif color_attr:
+            self.header.setBrush(QtGui.QBrush(QtGui.QColor(color_attr)))
         self.title_item = QtWidgets.QGraphicsSimpleTextItem(title, self)
         # optional subtitle (e.g., variable name)
         subtitle = self._params.get('subtitle') if isinstance(self._params, dict) else None


### PR DESCRIPTION
## Summary
- add constant nodes for int, float, bool, and string variables
- color nodes via class COLOR attributes and support generic object connections

## Testing
- `python -m py_compile app/ui/graph.py app/nodes/constants.py app/nodes/__init__.py app/nodes/variables_runtime.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07fd57aa8832dbbd6f624530fc34f