### PR TITLE
feat: add event-driven scheduler

### DIFF
--- a/app/core/engine_async.py
+++ b/app/core/engine_async.py
@@ -1,44 +1,30 @@
-
 from PyQt5 import QtCore
-from .engine import ExecutionEngine
+
+from .scheduler import Scheduler
+
 
 class _HooksBridge:
-    def __init__(self, emitter): self._emitter = emitter
-    def on_node_start(self, nid: str): self._emitter.sigNodeStarted.emit(nid)
-    def on_node_finish(self, nid: str): self._emitter.sigNodeFinished.emit(nid)
+    """Forward scheduler callbacks to EngineRunner signals."""
+
+    def __init__(self, runner):
+        self._runner = runner
+
+    def on_node_start(self, nid: str):
+        self._runner.sigNodeStarted.emit(nid)
+
+    def on_node_finish(self, nid: str):
+        self._runner.sigNodeFinished.emit(nid)
+
     def on_edge_fired(self, src_id: str, src_port: str, dst_id: str, dst_port: str):
-        self._emitter.sigEdgeFired.emit(src_id, src_port, dst_id, dst_port)
-    def on_node_output(self, nid: str, out: dict): self._emitter.sigNodeOutput.emit(nid, out)
+        self._runner.sigEdgeFired.emit(src_id, src_port, dst_id, dst_port)
 
-class EngineWorker(QtCore.QObject):
-    sigRunStarted = QtCore.pyqtSignal()
-    sigRunFinished = QtCore.pyqtSignal(dict)
-    sigNodeStarted = QtCore.pyqtSignal(str)
-    sigNodeFinished = QtCore.pyqtSignal(str)
-    sigEdgeFired = QtCore.pyqtSignal(str, str, str, str)
-    sigNodeOutput = QtCore.pyqtSignal(str, dict)
-    sigError = QtCore.pyqtSignal(str)
+    def on_node_output(self, nid: str, out: dict):
+        self._runner.sigNodeOutput.emit(nid, out)
 
-    @QtCore.pyqtSlot(list, list, dict)
-    def start_run(self, nodes, edges, vars_init):
-        try:
-            self.sigRunStarted.emit()
-            hooks = _HooksBridge(self)
-            self._engine = ExecutionEngine(nodes, edges, hooks=hooks, vars_init=vars_init)
-            results = self._engine.run()
-            self.sigRunFinished.emit(results)
-            self._engine = None
-        except Exception as e:
-            self.sigError.emit(str(e))
-
-    def cancel(self):
-        try:
-            if hasattr(self, "_engine") and self._engine and hasattr(self._engine, "request_cancel"):
-                self._engine.request_cancel()
-        except Exception:
-            pass
 
 class EngineRunner(QtCore.QObject):
+    """Asynchronous engine powered by :class:`Scheduler` in the main thread."""
+
     sigRunStarted = QtCore.pyqtSignal()
     sigRunFinished = QtCore.pyqtSignal(dict)
     sigNodeStarted = QtCore.pyqtSignal(str)
@@ -49,29 +35,24 @@ class EngineRunner(QtCore.QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._thread = QtCore.QThread(self)
-        self._worker = EngineWorker()
-        self._worker.moveToThread(self._thread)
-        # bubble up
-        self._worker.sigRunStarted.connect(self.sigRunStarted)
-        self._worker.sigRunFinished.connect(self.sigRunFinished)
-        self._worker.sigNodeStarted.connect(self.sigNodeStarted)
-        self._worker.sigNodeFinished.connect(self.sigNodeFinished)
-        self._worker.sigEdgeFired.connect(self.sigEdgeFired)
-        self._worker.sigNodeOutput.connect(self.sigNodeOutput)
-        self._worker.sigError.connect(self.sigError)
-        self._thread.start()
+        self._scheduler: Scheduler | None = None
 
     def start(self, nodes, edges, vars_init=None):
-        QtCore.QMetaObject.invokeMethod(self._worker, "start_run", QtCore.Qt.QueuedConnection,
-                                        QtCore.Q_ARG(list, nodes), QtCore.Q_ARG(list, edges), QtCore.Q_ARG(dict, vars_init or {}))
+        try:
+            self.sigRunStarted.emit()
+            hooks = _HooksBridge(self)
+            self._scheduler = Scheduler(hooks=hooks)
+            self._scheduler.sigRunFinished.connect(self.sigRunFinished)
+            self._scheduler.setup(nodes, edges, vars_init or {})
+            QtCore.QTimer.singleShot(0, self._scheduler.start_run)
+        except Exception as e:  # pragma: no cover - forward error
+            self.sigError.emit(str(e))
 
     def stop(self):
-        self._worker.cancel()
+        if self._scheduler:
+            self._scheduler.cancel_all()
 
-    def deleteLater(self):
-        try:
-            self._thread.quit(); self._thread.wait(5000)
-        except Exception:
-            pass
+    def deleteLater(self):  # pragma: no cover - Qt cleanup
+        self._scheduler = None
         super().deleteLater()
+

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Any, Optional, Tuple
+from collections import deque, defaultdict
+from PyQt5 import QtCore
+
+from .engine import DEFAULT_PREFIX, NodeSpec, EdgeSpec
+from .registry import registry
+
+
+@dataclass
+class Token:
+    id: int
+    target: str
+    data: Dict[str, Any]
+    cancelled: bool = False
+
+
+class Scheduler(QtCore.QObject):
+    """Single-threaded scheduler driving node execution."""
+
+    sigRunFinished = QtCore.pyqtSignal(dict)
+
+    def __init__(self, parent=None, hooks: Optional[object] = None):
+        super().__init__(parent)
+        self.hooks = hooks
+        self.ready: deque[int] = deque()
+        self.nodes: Dict[str, Any] = {}
+        self.tokens: Dict[int, Token] = {}
+        self.results: Dict[str, Dict[str, Any]] = {}
+        self.vars: Dict[str, Any] = {}
+        self.data_incoming: Dict[Tuple[str, str], Tuple[str, str]] = {}
+        self.exec_outgoing: Dict[Tuple[str, str], List[Tuple[str, str]]] = defaultdict(list)
+        self._next_token = 1
+        self._draining = False
+        self._active = 0
+        self._pure_nodes: List[str] = []
+        self._exec_nodes: List[str] = []
+
+    # ---- graph setup --------------------------------------------------
+    def setup(self, nodes: List[NodeSpec], edges: List[EdgeSpec], vars_init: Dict[str, Any]):
+        self.ready.clear()
+        self.tokens.clear()
+        self.results.clear()
+        self.vars = dict(vars_init or {})
+        self.data_incoming.clear()
+        self.exec_outgoing.clear()
+        self.nodes.clear()
+        self._pure_nodes.clear()
+        self._exec_nodes.clear()
+        self._next_token = 1
+        self._active = 0
+
+        for spec in nodes:
+            inst = registry.create(spec.type_name, **spec.params)
+            inst.attach(self, spec.id)
+            setattr(inst, "_engine", self)  # for variable nodes
+            self.nodes[spec.id] = inst
+        for e in edges:
+            if e.kind == "data":
+                self.data_incoming[(e.dst_id, e.dst_port)] = (e.src_id, e.src_port)
+            else:
+                self.exec_outgoing[(e.src_id, e.src_port)].append((e.dst_id, e.dst_port))
+        for nid, inst in self.nodes.items():
+            if inst.exec_inputs() or inst.exec_outputs():
+                self._exec_nodes.append(nid)
+            else:
+                self._pure_nodes.append(nid)
+
+    # ---- data helpers --------------------------------------------------
+    def _build_data_graph(self, only_nodes: List[str]):
+        adj = {nid: [] for nid in only_nodes}
+        indeg = {nid: 0 for nid in only_nodes}
+        for (dst_id, dst_port), (src_id, src_port) in self.data_incoming.items():
+            if dst_id in indeg and src_id in indeg:
+                adj[src_id].append(dst_id)
+                indeg[dst_id] += 1
+        return adj, indeg
+
+    def _topological_order_subset(self, subset: List[str]) -> List[str]:
+        adj, indeg = self._build_data_graph(subset)
+        q = [nid for nid in subset if indeg[nid] == 0]
+        order = []
+        while q:
+            nid = q.pop(0)
+            order.append(nid)
+            for nxt in adj[nid]:
+                indeg[nxt] -= 1
+                if indeg[nxt] == 0:
+                    q.append(nxt)
+        return order
+
+    def _gather_inputs(self, nid: str) -> Dict[str, Any]:
+        node = self.nodes[nid]
+        params = node.params()
+        kwargs = {}
+        for in_name in node.inputs().keys():
+            if (nid, in_name) in self.data_incoming:
+                src_id, src_port = self.data_incoming[(nid, in_name)]
+                kwargs[in_name] = self.results.get(src_id, {}).get(src_port)
+            else:
+                key = DEFAULT_PREFIX + in_name
+                kwargs[in_name] = params.get(key, None)
+        return kwargs
+
+    # ---- token helpers -------------------------------------------------
+    def _new_token(self, nid: str, data: Optional[Dict[str, Any]] = None) -> int:
+        tid = self._next_token
+        self._next_token += 1
+        self.tokens[tid] = Token(tid, nid, data or {})
+        self._active += 1
+        return tid
+
+    def post_ready(self, tid: int) -> None:
+        self.ready.append(tid)
+        QtCore.QTimer.singleShot(0, self.drain)
+
+    # ---- running -------------------------------------------------------
+    def start_run(self):
+        # evaluate pure nodes synchronously
+        if self._pure_nodes:
+            order = self._topological_order_subset(self._pure_nodes)
+            for nid in order:
+                node = self.nodes[nid]
+                out = node.process(**self._gather_inputs(nid)) or {}
+                self.results[nid] = out
+        # entry nodes have no exec inputs
+        entry_nodes = [nid for nid in self._exec_nodes if not self.nodes[nid].exec_inputs()]
+        for nid in entry_nodes:
+            tid = self._new_token(nid, {})
+            self.post_ready(tid)
+
+    def drain(self):
+        if self._draining:
+            return
+        self._draining = True
+        try:
+            while self.ready:
+                tid = self.ready.popleft()
+                tok = self.tokens.get(tid)
+                if not tok or tok.cancelled:
+                    continue
+                nid = tok.target
+                node = self.nodes[nid]
+                if node.busy:
+                    node.enqueue_local(tid)
+                    continue
+                node.busy = True
+                if self.hooks and hasattr(self.hooks, "on_node_start"):
+                    try:
+                        self.hooks.on_node_start(nid)
+                    except Exception:
+                        pass
+                kwargs = self._gather_inputs(nid)
+                node.start(tid, **kwargs)
+        finally:
+            self._draining = False
+
+    # called by nodes when finished
+    def on_node_finished(self, nid: str, tid: int, next_ports: Optional[List[str]], out: Optional[Dict[str, Any]]):
+        node = self.nodes[nid]
+        node.busy = False
+        self.tokens.pop(tid, None)
+        self._active -= 1
+        prev = self.results.get(nid, {})
+        prev.update(out or {})
+        self.results[nid] = prev
+        if self.hooks and hasattr(self.hooks, "on_node_output"):
+            try:
+                self.hooks.on_node_output(nid, out or {})
+            except Exception:
+                pass
+        if self.hooks and hasattr(self.hooks, "on_node_finish"):
+            try:
+                self.hooks.on_node_finish(nid)
+            except Exception:
+                pass
+        # start next token from local queue if any
+        nxt = node.dequeue_local()
+        if nxt is not None:
+            node.busy = True
+            if self.hooks and hasattr(self.hooks, "on_node_start"):
+                try:
+                    self.hooks.on_node_start(nid)
+                except Exception:
+                    pass
+            kwargs = self._gather_inputs(nid)
+            node.start(nxt, **kwargs)
+        # propagate exec edges
+        for port in next_ports or []:
+            for (dst_id, dst_port) in self.exec_outgoing.get((nid, port), []):
+                if self.hooks and hasattr(self.hooks, "on_edge_fired"):
+                    try:
+                        self.hooks.on_edge_fired(nid, port, dst_id, dst_port)
+                    except Exception:
+                        pass
+                child = self._new_token(dst_id, {})
+                self.post_ready(child)
+        # run finished?
+        if self._active == 0 and not self.ready:
+            QtCore.QTimer.singleShot(0, lambda: self.sigRunFinished.emit(dict(self.results)))
+
+    # cancellation -------------------------------------------------------
+    def cancel_all(self) -> None:
+        for tok in self.tokens.values():
+            tok.cancelled = True
+        for node in self.nodes.values():
+            try:
+                node.cancel()
+            except Exception:
+                pass
+        self.tokens.clear()
+        self.ready.clear()
+        self._active = 0
+        QtCore.QTimer.singleShot(0, lambda: self.sigRunFinished.emit(dict(self.results)))

--- a/app/nodes/base.py
+++ b/app/nodes/base.py
@@ -1,9 +1,18 @@
 from typing import Dict, Any, List, Tuple
+from collections import deque
+from PyQt5 import QtCore
+
 
 class BaseNode:
     reentrant: bool = False
+
     def __init__(self, **params):
         self._params = params
+        # scheduler will attach itself to nodes at run time
+        self._scheduler = None  # type: ignore
+        self._nid: str | None = None
+        self.busy: bool = False
+        self._local_q: deque[int] = deque()
 
     @classmethod
     def type_name(cls) -> str:
@@ -41,3 +50,31 @@ class BaseNode:
     def on_exec(self, **kwargs) -> Tuple[list, dict]:
         outs = list(self.exec_outputs())[:1]
         return outs, {}
+
+    # ----- scheduler integration -----
+    def attach(self, scheduler, nid: str) -> None:
+        """Called by the scheduler to give context about the graph."""
+        self._scheduler = scheduler
+        self._nid = nid
+
+    # local FIFO for single-seat behaviour
+    def enqueue_local(self, token_id: int) -> None:
+        self._local_q.append(token_id)
+
+    def dequeue_local(self) -> int | None:
+        return self._local_q.popleft() if self._local_q else None
+
+    # default start implementation for synchronous nodes
+    def start(self, token_id: int, **kwargs) -> None:
+        outs, data = self.on_exec(**kwargs)
+        # bounce back to scheduler asynchronously to avoid re-entrancy
+        QtCore.QTimer.singleShot(
+            0,
+            lambda: self._scheduler.on_node_finished(
+                self._nid, token_id, outs, data
+            ),
+        )
+
+    # optional cancel hook for slow nodes
+    def cancel(self) -> None:  # pragma: no cover - default noop
+        pass

--- a/app/nodes/control.py
+++ b/app/nodes/control.py
@@ -57,20 +57,21 @@ class Delay(BaseNode):
     def category(cls):
         return "Contrôle"
 
-    def on_exec(self, seconds=None, **_) -> Tuple[List[str], Dict[str, Any]]:
+    def start(self, token_id: int, seconds=None, **_):
+        from PyQt5 import QtCore
+
         try:
             secs = float(0.0 if seconds is None else seconds)
         except Exception:
             secs = 0.0
-        # Non-blocking-ish wait to keep UI responsive
-        try:
-            from PyQt5.QtCore import QCoreApplication
-            import time as _t
-            end = _t.monotonic() + max(0.0, secs)
-            while _t.monotonic() < end:
-                QCoreApplication.processEvents()
-                _t.sleep(0.01)
-        except Exception:
-            import time as _t
-            _t.sleep(max(0.0, secs))
-        return (["then"], {})
+
+        msecs = max(0, int(secs * 1000))
+        timer = QtCore.QTimer()
+        timer.setSingleShot(True)
+
+        def _done():
+            timer.deleteLater()
+            self._scheduler.on_node_finished(self._nid, token_id, ["then"], {})
+
+        timer.timeout.connect(_done)
+        timer.start(msecs)

--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -11,14 +11,21 @@ except Exception:
 from .base import BaseNode
 from ..core.registry import registry
 
+
 @registry.register
 class WaitSerialMessage(BaseNode, QtCore.QObject):
+    """Non-blocking wait for a line on a serial port."""
+
     reentrant: bool = False
     event_node: bool = True  # color as event
+
     def __init__(self, **params):
-        QtCore.QObject.__init__(self); BaseNode.__init__(self, **params)
+        QtCore.QObject.__init__(self)
+        BaseNode.__init__(self, **params)
         self._serial: Optional[QSerialPort] = None
         self._buffer = bytearray()
+        self._timer: Optional[QtCore.QTimer] = None
+        self._current_token: Optional[int] = None
 
     @classmethod
     def title(cls): return "Wait Serial Message"
@@ -42,20 +49,63 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
         return ok
 
     def _on_ready(self):
-        if not self._serial: return
+        if not self._serial:
+            return
         self._buffer.extend(self._serial.readAll().data())
         if b"\n" in self._buffer:
-            line, _, rest = self._buffer.partition(b"\n"); self._buffer = bytearray(rest)
-            self._last_text = line.decode(errors="replace").rstrip("\r")
-            if self._loop and self._loop.isRunning():
-                self._serial.close()
-                self._loop.quit()
+            line, _, rest = self._buffer.partition(b"\n")
+            self._buffer = bytearray(rest)
+            text = line.decode(errors="replace").rstrip("\r")
+            self._finish(text)
 
-    def on_exec(self, **kwargs) -> Tuple[List[str], Dict[str, Any]]:
-        port = kwargs.get("port") or self._params.get("port") or "COM3"
-        baud = kwargs.get("baud") or self._params.get("baud") or 115200
-        if not self._ensure_open(port, baud): raise RuntimeError(f"Impossible d'ouvrir {port}")
-        self._last_text = ""
-        self._loop = QtCore.QEventLoop()
-        self._loop.exec_()  # no timeout by design
-        return (["then"], {"text": self._last_text})
+    def _on_timeout(self):
+        self._finish("")
+
+    def _finish(self, text: str):
+        if self._serial:
+            try:
+                self._serial.readyRead.disconnect(self._on_ready)
+            except Exception:
+                pass
+            try:
+                self._serial.close()
+            except Exception:
+                pass
+        if self._timer:
+            self._timer.stop()
+            self._timer.deleteLater()
+            self._timer = None
+        token = self._current_token
+        self._current_token = None
+        QtCore.QTimer.singleShot(
+            0,
+            lambda: self._scheduler.on_node_finished(
+                self._nid, token, ["then"], {"text": text}
+            ),
+        )
+
+    def start(self, token_id: int, port=None, baud=None, **_):
+        if self._current_token is not None:
+            # shouldn't happen due to scheduler single-seat, but guard
+            self.enqueue_local(token_id)
+            return
+        port = port or self._params.get("port") or "COM3"
+        baud = baud or self._params.get("baud") or 115200
+        if not self._ensure_open(port, baud):
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self._scheduler.on_node_finished(
+                    self._nid, token_id, ["then"], {"text": ""}
+                ),
+            )
+            return
+        self._current_token = token_id
+        self._buffer.clear()
+        timeout_ms = int(self._params.get("timeout", 3000))
+        self._timer = QtCore.QTimer(self)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._on_timeout)
+        self._timer.start(timeout_ms)
+
+    def cancel(self) -> None:
+        self._finish("")


### PR DESCRIPTION
## Summary
- add single-threaded Scheduler orchestrating node execution
- make Delay node non-blocking via QTimer
- implement asynchronous WaitSerialMessage using readyRead and timeout
- expose EngineRunner using scheduler instead of worker thread

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pyflakes` *(fails: Could not find a version that satisfies the requirement pyflakes)*

------
https://chatgpt.com/codex/tasks/task_e_68a10408a8b0832db3b4073f6358b04a