### PR TITLE
Refactor serial COM port handling into dedicated nodes

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -1,5 +1,4 @@
-
-from typing import Dict, Any, List, Tuple, Optional
+from typing import List, Optional
 from PyQt5 import QtCore
 try:
     from PyQt5.QtSerialPort import QSerialPort
@@ -13,11 +12,94 @@ from ..core.registry import registry
 
 
 @registry.register
-class WaitSerialMessage(BaseNode, QtCore.QObject):
-    """Non-blocking wait for a line on a serial port."""
+class ConnectPortCom(BaseNode):
+    @classmethod
+    def title(cls): return "Connect Port Com"
 
+    @classmethod
+    def type_name(cls): return "ConnectPortCom"
+
+    @classmethod
+    def exec_inputs(cls): return ["in"]
+
+    @classmethod
+    def exec_outputs(cls): return ["then"]
+
+    @classmethod
+    def inputs(cls): return {"port": str, "baud": int}
+
+    @classmethod
+    def outputs(cls): return {"handle": object}
+
+    def on_exec(self, port=None, baud=None, **_):
+        if not HAVE_SERIAL:
+            raise RuntimeError("QtSerialPort manquant (PyQt5.QtSerialPort).")
+        port = port or self._params.get("port") or "COM3"
+        baud = baud or self._params.get("baud") or 115200
+        ser = QSerialPort()
+        ser.setPortName(str(port))
+        ser.setBaudRate(int(baud) or 115200)
+        ok = ser.open(QSerialPort.ReadWrite)
+        return (["then"], {"handle": ser if ok else None})
+
+
+@registry.register
+class DisconnectPortCom(BaseNode):
+    @classmethod
+    def title(cls): return "Disconnect Port Com"
+
+    @classmethod
+    def type_name(cls): return "DisconnectPortCom"
+
+    @classmethod
+    def exec_inputs(cls): return ["in"]
+
+    @classmethod
+    def exec_outputs(cls): return ["then"]
+
+    @classmethod
+    def inputs(cls): return {"handle": object}
+
+    def on_exec(self, handle=None, **_):
+        if HAVE_SERIAL and isinstance(handle, QSerialPort):
+            try:
+                handle.close()
+            except Exception:
+                pass
+        return (["then"], {})
+
+
+@registry.register
+class SendPortComMessage(BaseNode):
+    @classmethod
+    def title(cls): return "Send Port Com Message"
+
+    @classmethod
+    def type_name(cls): return "SendPortComMessage"
+
+    @classmethod
+    def exec_inputs(cls): return ["in"]
+
+    @classmethod
+    def exec_outputs(cls): return ["then"]
+
+    @classmethod
+    def inputs(cls): return {"handle": object, "text": str}
+
+    def on_exec(self, handle=None, text=None, **_):
+        if HAVE_SERIAL and isinstance(handle, QSerialPort) and handle.isOpen():
+            data = (text or "").encode()
+            try:
+                handle.write(data)
+            except Exception:
+                pass
+        return (["then"], {})
+
+
+@registry.register
+class OnPortComMessage(BaseNode, QtCore.QObject):
     reentrant: bool = False
-    event_node: bool = True  # color as event
+    event_node: bool = True
 
     def __init__(self, **params):
         QtCore.QObject.__init__(self)
@@ -28,25 +110,22 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
         self._current_token: Optional[int] = None
 
     @classmethod
-    def title(cls): return "Wait Serial Message"
+    def title(cls): return "On Port Com Message"
+
     @classmethod
-    def type_name(cls): return "WaitSerialMessage"
+    def type_name(cls): return "OnPortComMessage"
+
     @classmethod
-    def inputs(cls): return {"port": str, "baud": int}
+    def inputs(cls): return {"handle": object}
+
     @classmethod
     def outputs(cls): return {"text": str}
+
+    @classmethod
+    def exec_inputs(cls): return ["in"]
+
     @classmethod
     def exec_outputs(cls) -> List[str]: return ["then"]
-
-    def _ensure_open(self, port: str, baud: int) -> bool:
-        if not HAVE_SERIAL: raise RuntimeError("QtSerialPort manquant (PyQt5.QtSerialPort).")
-        if self._serial and self._serial.isOpen():
-            if self._serial.portName()==port and self._serial.baudRate()==baud: return True
-            self._serial.close()
-        self._serial = QSerialPort(); self._serial.setPortName(port); self._serial.setBaudRate(baud or 115200)
-        ok = self._serial.open(QSerialPort.ReadOnly)
-        if ok: self._serial.readyRead.connect(self._on_ready)
-        return ok
 
     def _on_ready(self):
         if not self._serial:
@@ -58,6 +137,9 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
             text = line.decode(errors="replace").rstrip("\r")
             self._finish(text)
 
+    def _on_error(self, *_):
+        self._finish("")
+
     def _on_timeout(self):
         self._finish("")
 
@@ -68,7 +150,7 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
             except Exception:
                 pass
             try:
-                self._serial.close()
+                self._serial.errorOccurred.disconnect(self._on_error)
             except Exception:
                 pass
         if self._timer:
@@ -77,6 +159,7 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
             self._timer = None
         token = self._current_token
         self._current_token = None
+        self._serial = None
         QtCore.QTimer.singleShot(
             0,
             lambda: self._scheduler.on_node_finished(
@@ -84,23 +167,23 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
             ),
         )
 
-    def start(self, token_id: int, port=None, baud=None, **_):
+    def start(self, token_id: int, handle=None, **_):
         if self._current_token is not None:
-            # shouldn't happen due to scheduler single-seat, but guard
             self.enqueue_local(token_id)
             return
-        port = port or self._params.get("port") or "COM3"
-        baud = baud or self._params.get("baud") or 115200
-        if not self._ensure_open(port, baud):
+        if not (HAVE_SERIAL and isinstance(handle, QSerialPort) and handle.isOpen()):
             QtCore.QTimer.singleShot(
                 0,
-                lambda: self._scheduler.on_node_finished(
-                    self._nid, token_id, ["then"], {"text": ""}
+                lambda tid=token_id: self._scheduler.on_node_finished(
+                    self._nid, tid, ["then"], {"text": ""}
                 ),
             )
             return
         self._current_token = token_id
+        self._serial = handle
         self._buffer.clear()
+        self._serial.readyRead.connect(self._on_ready)
+        self._serial.errorOccurred.connect(self._on_error)
         timeout_ms = int(self._params.get("timeout", 3000))
         self._timer = QtCore.QTimer(self)
         self._timer.setSingleShot(True)
@@ -109,3 +192,4 @@ class WaitSerialMessage(BaseNode, QtCore.QObject):
 
     def cancel(self) -> None:
         self._finish("")
+


### PR DESCRIPTION
## Summary
- split monolithic WaitSerialMessage into dedicated serial nodes
- add ConnectPortCom, DisconnectPortCom, SendPortComMessage, and OnPortComMessage
- OnPortComMessage reads data asynchronously with readyRead/error and timeout handling

## Testing
- `python -m py_compile app/nodes/serial.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a1bb5131d0832d80f35fb0428a40c8