### PR TITLE
Refactor serial listener and adjust exec pin linking

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -98,52 +98,59 @@ class SendPortComMessage(BaseNode):
 
 @registry.register
 class OnPortComMessage(BaseNode, QtCore.QObject):
+    """Listen to a serial port and emit an execution for each received line."""
+
     reentrant: bool = False
     event_node: bool = True
 
     def __init__(self, **params):
+        # default state for enabled input is True
+        params.setdefault("in_default:enabled", True)
         QtCore.QObject.__init__(self)
         BaseNode.__init__(self, **params)
         self._serial: Optional[QSerialPort] = None
         self._buffer = bytearray()
-        self._timer: Optional[QtCore.QTimer] = None
-        self._current_token: Optional[int] = None
+        self._active = False  # phantom token state
 
     @classmethod
-    def title(cls): return "On Port Com Message"
+    def title(cls):
+        return "On Port Com Message"
 
     @classmethod
-    def type_name(cls): return "OnPortComMessage"
+    def type_name(cls):
+        return "OnPortComMessage"
 
     @classmethod
-    def inputs(cls): return {"handle": object}
+    def inputs(cls):
+        return {"serial_port": object, "enabled": bool}
 
     @classmethod
-    def outputs(cls): return {"text": str}
+    def outputs(cls):
+        return {"text": str}
 
     @classmethod
-    def exec_inputs(cls): return ["in"]
+    def exec_inputs(cls) -> List[str]:
+        return ["exec_in"]
 
     @classmethod
-    def exec_outputs(cls) -> List[str]: return ["then"]
+    def exec_outputs(cls) -> List[str]:
+        return ["exec_out_pass", "exec_on_message"]
 
-    def _on_ready(self):
-        if not self._serial:
-            return
-        self._buffer.extend(self._serial.readAll().data())
-        if b"\n" in self._buffer:
-            line, _, rest = self._buffer.partition(b"\n")
-            self._buffer = bytearray(rest)
-            text = line.decode(errors="replace").rstrip("\r")
-            self._finish(text)
+    # ----- internal helpers -----
+    def _activate(self, handle: QSerialPort) -> None:
+        self._serial = handle
+        self._buffer.clear()
+        self._serial.readyRead.connect(self._on_ready)
+        self._serial.errorOccurred.connect(self._on_error)
+        self._active = True
+        hooks = getattr(self._scheduler, "hooks", None)
+        if hooks and hasattr(hooks, "on_node_start"):
+            try:
+                hooks.on_node_start(self._nid)
+            except Exception:
+                pass
 
-    def _on_error(self, *_):
-        self._finish("")
-
-    def _on_timeout(self):
-        self._finish("")
-
-    def _finish(self, text: str):
+    def _deactivate(self) -> None:
         if self._serial:
             try:
                 self._serial.readyRead.disconnect(self._on_ready)
@@ -153,43 +160,66 @@ class OnPortComMessage(BaseNode, QtCore.QObject):
                 self._serial.errorOccurred.disconnect(self._on_error)
             except Exception:
                 pass
-        if self._timer:
-            self._timer.stop()
-            self._timer.deleteLater()
-            self._timer = None
-        token = self._current_token
-        self._current_token = None
         self._serial = None
+        self._buffer.clear()
+        if self._active:
+            hooks = getattr(self._scheduler, "hooks", None)
+            if hooks and hasattr(hooks, "on_node_finish"):
+                try:
+                    hooks.on_node_finish(self._nid)
+                except Exception:
+                    pass
+        self._active = False
+
+    # ----- serial callbacks -----
+    def _on_ready(self):
+        if not (self._serial and self._active):
+            return
+        self._buffer.extend(self._serial.readAll().data())
+        while b"\n" in self._buffer:
+            line, _, rest = self._buffer.partition(b"\n")
+            self._buffer = bytearray(rest)
+            text = line.decode(errors="replace").rstrip("\r")
+            self._emit_message(text)
+
+    def _on_error(self, *_):
+        self._deactivate()
+
+    def _emit_message(self, text: str) -> None:
+        sched = self._scheduler
+        if not sched:
+            return
+        prev = sched.results.get(self._nid, {})
+        prev.update({"text": text})
+        sched.results[self._nid] = prev
+        hooks = getattr(sched, "hooks", None)
+        if hooks and hasattr(hooks, "on_node_output"):
+            try:
+                hooks.on_node_output(self._nid, {"text": text})
+            except Exception:
+                pass
+        for dst_id, dst_port in sched.exec_outgoing.get((self._nid, "exec_on_message"), []):
+            if hooks and hasattr(hooks, "on_edge_fired"):
+                try:
+                    hooks.on_edge_fired(self._nid, "exec_on_message", dst_id, dst_port)
+                except Exception:
+                    pass
+            child = sched._new_token(dst_id, {})
+            sched.post_ready(child)
+
+    # ----- execution entry -----
+    def start(self, token_id: int, serial_port=None, enabled=True, **_):
         QtCore.QTimer.singleShot(
             0,
-            lambda: self._scheduler.on_node_finished(
-                self._nid, token, ["then"], {"text": text}
+            lambda tid=token_id: self._scheduler.on_node_finished(
+                self._nid, tid, ["exec_out_pass"], {}
             ),
         )
+        if self._active:
+            self._deactivate()
+        if enabled and HAVE_SERIAL and isinstance(serial_port, QSerialPort) and serial_port.isOpen():
+            self._activate(serial_port)
 
-    def start(self, token_id: int, handle=None, **_):
-        if self._current_token is not None:
-            self.enqueue_local(token_id)
-            return
-        if not (HAVE_SERIAL and isinstance(handle, QSerialPort) and handle.isOpen()):
-            QtCore.QTimer.singleShot(
-                0,
-                lambda tid=token_id: self._scheduler.on_node_finished(
-                    self._nid, tid, ["then"], {"text": ""}
-                ),
-            )
-            return
-        self._current_token = token_id
-        self._serial = handle
-        self._buffer.clear()
-        self._serial.readyRead.connect(self._on_ready)
-        self._serial.errorOccurred.connect(self._on_error)
-        timeout_ms = int(self._params.get("timeout", 3000))
-        self._timer = QtCore.QTimer(self)
-        self._timer.setSingleShot(True)
-        self._timer.timeout.connect(self._on_timeout)
-        self._timer.start(timeout_ms)
-
-    def cancel(self) -> None:
-        self._finish("")
+    def cancel(self) -> None:  # pragma: no cover - defensive cleanup
+        self._deactivate()
 

--- a/app/ui/graph.py
+++ b/app/ui/graph.py
@@ -610,13 +610,28 @@ class GraphScene(QtWidgets.QGraphicsScene):
         super().mousePressEvent(event)
 
     def _is_link_allowed(self, src: PortItem, dst: PortItem) -> bool:
-        if src.kind != dst.kind: return False
-        if dst.is_output or src.is_output is False: return False
+        if src.kind != dst.kind:
+            return False
+        if dst.is_output or not src.is_output:
+            return False
+        if src.kind == "exec":
+            for e in list(src.edges):
+                self.removeItem(e)
+                src.remove_edge(e)
+                if e.dst_port:
+                    e.dst_port.remove_edge(e)
+                if e in self.edges:
+                    self.edges.remove(e)
+            return True
         for e in list(dst.edges):
-            self.removeItem(e); dst.remove_edge(e)
-            if e.src_port: e.src_port.remove_edge(e)
-            if e in self.edges: self.edges.remove(e)
-        if src.kind == "data": return is_compatible(src.dtype, dst.dtype)
+            self.removeItem(e)
+            dst.remove_edge(e)
+            if e.src_port:
+                e.src_port.remove_edge(e)
+            if e in self.edges:
+                self.edges.remove(e)
+        if src.kind == "data":
+            return is_compatible(src.dtype, dst.dtype)
         return True
 
     def mouseMoveEvent(self, event):


### PR DESCRIPTION
## Summary
- Refactor `OnPortComMessage` node to always pass through execution tokens, stay active via an internal phantom token and emit per-line messages when enabled
- Support enabling/disabling of the serial listener with a boolean input and remove blocking timeouts
- Restrict execution outputs to a single connection while allowing multiple outputs to join the same input

## Testing
- `python -m py_compile app/nodes/serial.py app/ui/graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef46963c832dbf2956f51f91abfb