### PR TITLE
Homogénéisation du type booléen pour les variables

### DIFF
--- a/app/nodes/variables_runtime.py
+++ b/app/nodes/variables_runtime.py
@@ -7,10 +7,16 @@ _TYPE_MAP = { 'String': str, 'Int': int, 'Float': float, 'Bool': bool }
 
 def _cast(val, tname: str):
     typ = _TYPE_MAP.get(tname, str)
-    if val is None: return typ() if typ is not str else ''
-    if typ is bool: return bool(val)
-    try: return typ(val)
-    except Exception: return val
+    if val is None:
+        return typ() if typ is not str else ''
+    if typ is bool:
+        if isinstance(val, str):
+            return val.strip().lower() in {"true", "1", "yes", "y", "on"}
+        return bool(val)
+    try:
+        return typ(val)
+    except Exception:
+        return val
 
 @registry.register
 class GetVariable(BaseNode):

--- a/tests/test_boolean_cast.py
+++ b/tests/test_boolean_cast.py
@@ -1,0 +1,17 @@
+import pytest
+from app.nodes.variables_runtime import _cast
+
+@pytest.mark.parametrize("input_val, expected", [
+    ("True", True),
+    ("true", True),
+    ("False", False),
+    ("false", False),
+    ("1", True),
+    ("0", False),
+    ("yes", True),
+    ("no", False),
+    (True, True),
+    (False, False),
+])
+def test_cast_bool(input_val, expected):
+    assert _cast(input_val, "Bool") == expected


### PR DESCRIPTION
## Résumé
- Interprétation fiable des chaînes booléennes pour `SetVariable` et `GetVariable`.
- Ajout de tests couvrant les différentes valeurs booléennes utilisateur.

## Tests
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a21521d98c832dab13dbcddfaca291