### PR TITLE
Add IsValid node for serial handle validation

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -70,6 +70,33 @@ class DisconnectPortCom(BaseNode):
 
 
 @registry.register
+class IsValid(BaseNode):
+    @classmethod
+    def title(cls):
+        return "Is Valid"
+
+    @classmethod
+    def type_name(cls):
+        return "IsValid"
+
+    @classmethod
+    def exec_inputs(cls) -> List[str]:
+        return ["in"]
+
+    @classmethod
+    def exec_outputs(cls) -> List[str]:
+        return ["valid", "invalid"]
+
+    @classmethod
+    def inputs(cls):
+        return {"handle": object}
+
+    def on_exec(self, handle=None, **_):
+        port = "valid" if handle else "invalid"
+        return ([port], {})
+
+
+@registry.register
 class SendPortComMessage(BaseNode):
     @classmethod
     def title(cls): return "Send Port Com Message"

--- a/tests/test_is_valid_node.py
+++ b/tests/test_is_valid_node.py
@@ -1,0 +1,11 @@
+from app.nodes.serial import IsValid
+
+
+def test_isvalid_node_valid_and_invalid():
+    node = IsValid()
+    outs, data = node.on_exec(handle=object())
+    assert outs == ["valid"]
+    assert data == {}
+    outs, data = node.on_exec(handle=None)
+    assert outs == ["invalid"]
+    assert data == {}


### PR DESCRIPTION
## Summary
- add IsValid node to validate serial port handles
- cover valid and invalid cases with new unit tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21de3caa4832d82028abf563961d3