### PR TITLE
feat: expose serial connection status

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -29,7 +29,8 @@ class ConnectPortCom(BaseNode):
     def inputs(cls): return {"port": str, "baud": int}
 
     @classmethod
-    def outputs(cls): return {"handle": object}
+    def outputs(cls):
+        return {"handle": object, "connected": bool}
 
     def on_exec(self, port=None, baud=None, **_):
         if not HAVE_SERIAL:
@@ -40,7 +41,7 @@ class ConnectPortCom(BaseNode):
         ser.setPortName(str(port))
         ser.setBaudRate(int(baud) or 115200)
         ok = ser.open(QSerialPort.ReadWrite)
-        return (["then"], {"handle": ser if ok else None})
+        return (["then"], {"handle": ser if ok else None, "connected": ok})
 
 
 @registry.register

--- a/tests/test_connect_port_com.py
+++ b/tests/test_connect_port_com.py
@@ -1,0 +1,39 @@
+import types
+from app.nodes import serial
+from app.nodes.serial import ConnectPortCom
+
+
+class DummySerialPort:
+    ReadWrite = object()
+    open_result = True
+
+    def setPortName(self, name):
+        pass
+
+    def setBaudRate(self, baud):
+        pass
+
+    def open(self, mode):
+        return self.open_result
+
+
+def test_connect_port_com_success(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    serial.QSerialPort.open_result = True
+    node = ConnectPortCom()
+    outs, data = node.on_exec(port="COM1", baud=9600)
+    assert outs == ["then"]
+    assert isinstance(data["handle"], serial.QSerialPort)
+    assert data["connected"] is True
+
+
+def test_connect_port_com_failure(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    serial.QSerialPort.open_result = False
+    node = ConnectPortCom()
+    outs, data = node.on_exec(port="COM1", baud=9600)
+    assert outs == ["then"]
+    assert data["handle"] is None
+    assert data["connected"] is False


### PR DESCRIPTION
## Summary
- add `connected` boolean output to `ConnectPortCom`
- cover success and failure cases with new tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21f7450f8832d95d0a54c2f29dafd