### PR TITLE
Add text comparison and concatenation nodes

### DIFF
--- a/app/nodes/__init__.py
+++ b/app/nodes/__init__.py
@@ -1,5 +1,5 @@
 
-from . import base, control, convert, math
+from . import base, control, convert, math, text
 # optional: serial node
 try:
     from . import serial  # noqa: F401

--- a/app/nodes/text.py
+++ b/app/nodes/text.py
@@ -1,0 +1,41 @@
+from typing import Dict, Any
+from .base import BaseNode
+from ..core.registry import registry
+
+@registry.register
+class IsEgalText(BaseNode):
+    @classmethod
+    def category(cls):
+        return "Text"
+
+    @classmethod
+    def inputs(cls):
+        return {"a": str, "b": str}
+
+    @classmethod
+    def outputs(cls):
+        return {"equal": bool}
+
+    def process(self, a=None, b=None, **_) -> Dict[str, Any]:
+        a = "" if a is None else str(a)
+        b = "" if b is None else str(b)
+        return {"equal": a == b}
+
+@registry.register
+class AppendText(BaseNode):
+    @classmethod
+    def category(cls):
+        return "Text"
+
+    @classmethod
+    def inputs(cls):
+        return {"a": str, "b": str}
+
+    @classmethod
+    def outputs(cls):
+        return {"text": str}
+
+    def process(self, a=None, b=None, **_) -> Dict[str, Any]:
+        a = "" if a is None else str(a)
+        b = "" if b is None else str(b)
+        return {"text": a + b}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_text_nodes.py
+++ b/tests/test_text_nodes.py
@@ -1,0 +1,13 @@
+from app.nodes.text import IsEgalText, AppendText
+
+
+def test_is_egal_text():
+    node = IsEgalText()
+    assert node.process(a="hello", b="hello") == {"equal": True}
+    assert node.process(a="hi", b="hello") == {"equal": False}
+
+
+def test_append_text():
+    node = AppendText()
+    assert node.process(a="hello", b=" world") == {"text": "hello world"}
+    assert node.process(a=None, b="foo") == {"text": "foo"}


### PR DESCRIPTION
## Summary
- Add `IsEgalText` and `AppendText` nodes for string equality and concatenation
- Register text node module
- Cover new nodes with unit tests

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a225e08a44832db92dcc891a455fe7