### PR TITLE
Add pause/resume controls and improved stop behavior

### DIFF
--- a/app/core/engine_async.py
+++ b/app/core/engine_async.py
@@ -52,6 +52,14 @@ class EngineRunner(QtCore.QObject):
         if self._scheduler:
             self._scheduler.cancel_all()
 
+    def pause(self):
+        if self._scheduler:
+            self._scheduler.pause_all()
+
+    def resume(self):
+        if self._scheduler:
+            self._scheduler.resume_all()
+
     def deleteLater(self):  # pragma: no cover - Qt cleanup
         self._scheduler = None
         super().deleteLater()

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -37,6 +37,7 @@ class Scheduler(QtCore.QObject):
         self._active = 0
         self._pure_nodes: List[str] = []
         self._exec_nodes: List[str] = []
+        self._paused = False
 
     # ---- graph setup --------------------------------------------------
     def setup(self, nodes: List[NodeSpec], edges: List[EdgeSpec], vars_init: Dict[str, Any]):
@@ -51,6 +52,7 @@ class Scheduler(QtCore.QObject):
         self._exec_nodes.clear()
         self._next_token = 1
         self._active = 0
+        self._paused = False
 
         for spec in nodes:
             inst = registry.create(spec.type_name, **spec.params)
@@ -114,7 +116,8 @@ class Scheduler(QtCore.QObject):
 
     def post_ready(self, tid: int) -> None:
         self.ready.append(tid)
-        QtCore.QTimer.singleShot(0, self.drain)
+        if not self._paused:
+            QtCore.QTimer.singleShot(0, self.drain)
 
     # ---- running -------------------------------------------------------
     def start_run(self):
@@ -132,7 +135,7 @@ class Scheduler(QtCore.QObject):
             self.post_ready(tid)
 
     def drain(self):
-        if self._draining:
+        if self._draining or self._paused:
             return
         self._draining = True
         try:
@@ -213,4 +216,24 @@ class Scheduler(QtCore.QObject):
         self.tokens.clear()
         self.ready.clear()
         self._active = 0
+        self._paused = False
         QtCore.QTimer.singleShot(0, lambda: self.sigRunFinished.emit(dict(self.results)))
+
+    # pause/resume ------------------------------------------------------
+    def pause_all(self) -> None:
+        self._paused = True
+        for node in self.nodes.values():
+            try:
+                node.pause()
+            except Exception:
+                pass
+
+    def resume_all(self) -> None:
+        self._paused = False
+        for node in self.nodes.values():
+            try:
+                node.resume()
+            except Exception:
+                pass
+        if self.ready:
+            QtCore.QTimer.singleShot(0, self.drain)

--- a/app/nodes/base.py
+++ b/app/nodes/base.py
@@ -78,3 +78,10 @@ class BaseNode:
     # optional cancel hook for slow nodes
     def cancel(self) -> None:  # pragma: no cover - default noop
         pass
+
+    # optional pause/resume hooks for long-running nodes
+    def pause(self) -> None:  # pragma: no cover - default noop
+        pass
+
+    def resume(self) -> None:  # pragma: no cover - default noop
+        pass

--- a/app/nodes/control.py
+++ b/app/nodes/control.py
@@ -36,6 +36,12 @@ class Print(BaseNode):
 
 @registry.register
 class Delay(BaseNode):
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._timer = None
+        self._remaining_ms = 0
+        self._current_token = None
+
     @classmethod
     def title(cls):
         return "Delay"
@@ -72,13 +78,43 @@ class Delay(BaseNode):
         except Exception:
             secs = 0.0
 
-        msecs = max(0, int(secs * 1000))
+        self._current_token = token_id
+        self._remaining_ms = max(0, int(secs * 1000))
 
-        # Timer sans lifetime à gérer → pas de GC aléatoire
-        QtCore.QTimer.singleShot(
-            msecs,
-            lambda tid=token_id: self._scheduler.on_node_finished(self._nid, tid, ["then"], {})
-        )
+        if self._timer:
+            self._timer.stop()
+            self._timer.deleteLater()
+
+        self._timer = QtCore.QTimer()
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._on_timeout)
+        self._timer.start(self._remaining_ms)
+
+    def _on_timeout(self):
+        tid = self._current_token
+        self._current_token = None
+        if self._timer:
+            self._timer.deleteLater()
+            self._timer = None
+        if tid is not None:
+            self._scheduler.on_node_finished(self._nid, tid, ["then"], {})
+
+    def cancel(self) -> None:
+        if self._timer:
+            self._timer.stop()
+            self._timer.deleteLater()
+            self._timer = None
+        self._current_token = None
+        self._remaining_ms = 0
+
+    def pause(self) -> None:
+        if self._timer and self._timer.isActive():
+            self._remaining_ms = self._timer.remainingTime()
+            self._timer.stop()
+
+    def resume(self) -> None:
+        if self._timer and not self._timer.isActive() and self._current_token is not None:
+            self._timer.start(self._remaining_ms)
 
 
 @registry.register

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -76,6 +76,8 @@ class MainWindow(QtWidgets.QMainWindow):
         tb = self.addToolBar("Main")
         runAct = tb.addAction("Run"); runAct.triggered.connect(self.run_graph)
         stopAct = tb.addAction("Stop"); stopAct.triggered.connect(self.stop_run)
+        pauseAct = tb.addAction("Pause"); pauseAct.setCheckable(True); pauseAct.triggered.connect(self.toggle_pause)
+        self.pauseAct = pauseAct
         clearAct = tb.addAction("Clear"); clearAct.triggered.connect(self.clear_graph)
         addCommentAct = tb.addAction("Commentaire"); addCommentAct.triggered.connect(self.add_comment_here)
 
@@ -180,11 +182,15 @@ class MainWindow(QtWidgets.QMainWindow):
         nodes, edges = self.scene.build_specs()
         try:
             init_vars = {name: val for name, (t, val) in self.var_defs.items()}
+            if hasattr(self, "pauseAct"):
+                self.pauseAct.setChecked(False)
             self.engine_runner.start(nodes, edges, init_vars)
         except Exception as e:
             self.log.appendPlainText(f"[ERREUR] {e}")
     
     def _on_engine_finished(self, results: dict):
+        if hasattr(self, "pauseAct"):
+            self.pauseAct.setChecked(False)
         # Affiche les impressions 'Print' à la fin d'un run async
         text_lines = []
         for nid, out in (results or {}).items():
@@ -302,5 +308,19 @@ class MainWindow(QtWidgets.QMainWindow):
             if hasattr(self, "engine_runner") and self.engine_runner is not None:
                 self.engine_runner.stop()
                 self.log.appendPlainText("[INFO] Arrêt demandé (Stop).")
+            if hasattr(self, "pauseAct"):
+                self.pauseAct.setChecked(False)
         except Exception as e:
             self.log.appendPlainText(f"[ERREUR] Stop: {e}")
+
+    def toggle_pause(self, checked):
+        try:
+            if hasattr(self, "engine_runner") and self.engine_runner is not None:
+                if checked:
+                    self.engine_runner.pause()
+                    self.log.appendPlainText("[INFO] Pause demandée.")
+                else:
+                    self.engine_runner.resume()
+                    self.log.appendPlainText("[INFO] Reprise.")
+        except Exception as e:
+            self.log.appendPlainText(f"[ERREUR] Pause: {e}")


### PR DESCRIPTION
## Summary
- allow nodes to expose pause/resume hooks
- make Delay node cancellable and pausable
- add scheduler pause/resume and propagate through EngineRunner and UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2300091e0832d88978f447b50322f