### PR TITLE
feat: persist log to disk

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1,4 +1,7 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
+from pathlib import Path
+from typing import Optional
+
 from .graph import GraphScene, GraphView, NodeItem, TYPE_COLORS, CommentItem
 from ..core.registry import registry
 from ..core.engine import ExecutionEngine
@@ -12,6 +15,27 @@ from ..nodes import variables_runtime as variable_nodes  # noqa: F401
 from ..nodes.variables_runtime import _cast as cast_var
 
 DTYPE_MAP = {'String': str, 'Int': int, 'Float': float, 'Bool': bool}
+
+
+class FileLogger(QtWidgets.QPlainTextEdit):
+    """Text logger that mirrors every line into a file."""
+
+    def __init__(self, path: Optional[Path] = None):
+        super().__init__()
+        self._path = path if path is not None else Path.cwd() / "app.log"
+        self._handle = self._path.open("a", encoding="utf-8")
+
+    def appendPlainText(self, text: str) -> None:  # type: ignore[override]
+        super().appendPlainText(text)
+        self._handle.write(text + "\n")
+        self._handle.flush()
+
+    def closeEvent(self, event):  # pragma: no cover - Qt behaviour
+        try:
+            self._handle.close()
+        finally:
+            super().closeEvent(event)
+
 
 class LegendWidget(QtWidgets.QWidget):
     def __init__(self):
@@ -69,7 +93,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.legendDock.setWidget(LegendWidget())
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea, self.legendDock)
 
-        self.log = QtWidgets.QPlainTextEdit(); self.log.setReadOnly(True)
+        self.log = FileLogger(); self.log.setReadOnly(True)
         self.logDock = QtWidgets.QDockWidget("Log", self); self.logDock.setWidget(self.log)
         self.addDockWidget(QtCore.Qt.BottomDockWidgetArea, self.logDock)
 

--- a/tests/test_file_logger.py
+++ b/tests/test_file_logger.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt5.QtWidgets")
+
+
+def test_file_logger_writes(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    app = QtWidgets.QApplication.instance()
+    created = False
+    if app is None:
+        app = QtWidgets.QApplication([])
+        created = True
+
+    from app.ui.main_window import FileLogger
+
+    log_path = tmp_path / "log.txt"
+    fl = FileLogger(log_path)
+    fl.appendPlainText("hello")
+    fl.close()
+
+    assert log_path.read_text().strip() == "hello"
+
+    if created:
+        app.quit()
+


### PR DESCRIPTION
## Summary
- add `FileLogger` that writes each log message to a file for resilience against crashes
- wire `MainWindow` to use `FileLogger` for real-time log persistence
- cover log persistence with a new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3816682d8832db5fa3aaf1a22d26e