### PR TITLE
Ensure newline termination in serial message sending

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -116,9 +116,16 @@ class SendPortComMessage(BaseNode):
 
     def on_exec(self, serial_port=None, text=None, **_):
         if HAVE_SERIAL and isinstance(serial_port, QSerialPort) and serial_port.isOpen():
-            data = (text or "").encode()
             try:
+                msg = text or ""
+                if not msg.endswith("\n"):
+                    msg += "\n"
+                data = msg.encode("utf-8")
                 serial_port.write(data)
+                try:
+                    serial_port.waitForBytesWritten(50)
+                except Exception:
+                    pass
             except Exception:
                 pass
         return (["then"], {})


### PR DESCRIPTION
## Summary
- Ensure SendPortComMessage appends newline, encodes in UTF-8, writes to serial port and waits for bytes to be written

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4df4dc480832dacc1366e23652313