### PR TITLE
Add JSON-based graph save and load

### DIFF
--- a/app/core/graph_io.py
+++ b/app/core/graph_io.py
@@ -1,0 +1,36 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import List, Tuple
+
+from .engine import NodeSpec, EdgeSpec
+
+
+def save_graph(nodes: List[NodeSpec], edges: List[EdgeSpec], path: str | Path) -> None:
+    """Save a graph to JSON file.
+
+    Only node identifiers, their type, parameters and edge endpoints are
+    stored. It is up to the application to recreate a visual layout from
+    this information when loading.
+    """
+    data = {
+        "nodes": [asdict(n) for n in nodes],
+        "edges": [asdict(e) for e in edges],
+    }
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def load_graph(path: str | Path) -> Tuple[List[NodeSpec], List[EdgeSpec]]:
+    """Load a graph from a JSON file.
+
+    Returns the list of nodes and edges found in the file. Unknown keys are
+    ignored. Missing sections default to empty lists.
+    """
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    nodes = [NodeSpec(**n) for n in data.get("nodes", [])]
+    edges = [EdgeSpec(**e) for e in data.get("edges", [])]
+    return nodes, edges

--- a/tests/test_graph_io.py
+++ b/tests/test_graph_io.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from app.core.engine import NodeSpec, EdgeSpec, ExecutionEngine, DEFAULT_PREFIX
+from app.core.graph_io import save_graph, load_graph
+
+# Ensure node classes are registered
+from app.nodes import control as _control_nodes  # noqa: F401
+from app.nodes import math as _math_nodes  # noqa: F401
+
+
+def test_save_and_load_graph(tmp_path: Path):
+    nodes = [
+        NodeSpec(id="n1", type_name="BeginPlay"),
+        NodeSpec(id="n2", type_name="Add", params={
+            DEFAULT_PREFIX + "a": 1,
+            DEFAULT_PREFIX + "b": 2,
+        }),
+        NodeSpec(id="n3", type_name="Print"),
+    ]
+    edges = [
+        EdgeSpec(kind="exec", src_id="n1", src_port="out", dst_id="n3", dst_port="in"),
+        EdgeSpec(kind="data", src_id="n2", src_port="sum", dst_id="n3", dst_port="text"),
+    ]
+
+    path = tmp_path / "graph.json"
+    save_graph(nodes, edges, path)
+    loaded_nodes, loaded_edges = load_graph(path)
+
+    assert loaded_nodes == nodes
+    assert loaded_edges == edges
+
+    engine = ExecutionEngine(loaded_nodes, loaded_edges, vars_init={})
+    results = engine.run()
+    assert results["n3"]["printed"] == 3.0


### PR DESCRIPTION
## Summary
- Add `graph_io` module to save and load graphs as JSON
- Cover graph persistence with new `test_graph_io`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a581a7ed50832db5f8c3a0219e3472