### PR TITLE
Add DTR control to ConnectPortCom node

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -26,21 +26,28 @@ class ConnectPortCom(BaseNode):
     def exec_outputs(cls): return ["then"]
 
     @classmethod
-    def inputs(cls): return {"port": str, "baud": int}
+    def inputs(cls):
+        return {"port": str, "baud": int, "dtr": bool}
 
     @classmethod
     def outputs(cls):
         return {"serial_port": QSerialPort, "connected": bool}
 
-    def on_exec(self, port=None, baud=None, **_):
+    def on_exec(self, port=None, baud=None, dtr=None, **_):
         if not HAVE_SERIAL:
             raise RuntimeError("QtSerialPort manquant (PyQt5.QtSerialPort).")
         port = port or self._params.get("port") or "COM3"
         baud = baud or self._params.get("baud") or 115200
+        dtr = dtr if dtr is not None else self._params.get("dtr", True)
         ser = QSerialPort()
         ser.setPortName(str(port))
         ser.setBaudRate(int(baud) or 115200)
         ok = ser.open(QSerialPort.ReadWrite)
+        if ok and dtr is not None:
+            try:
+                ser.setDataTerminalReady(bool(dtr))
+            except Exception:
+                pass
         return (["then"], {"serial_port": ser if ok else None, "connected": ok})
 
 

--- a/tests/test_connect_port_com.py
+++ b/tests/test_connect_port_com.py
@@ -6,6 +6,7 @@ from app.nodes.serial import ConnectPortCom
 class DummySerialPort:
     ReadWrite = object()
     open_result = True
+    dtr = None
 
     def setPortName(self, name):
         pass
@@ -15,6 +16,9 @@ class DummySerialPort:
 
     def open(self, mode):
         return self.open_result
+
+    def setDataTerminalReady(self, value):
+        self.dtr = value
 
 
 def test_connect_port_com_success(monkeypatch):
@@ -26,6 +30,7 @@ def test_connect_port_com_success(monkeypatch):
     assert outs == ["then"]
     assert isinstance(data["serial_port"], serial.QSerialPort)
     assert data["connected"] is True
+    assert data["serial_port"].dtr is True
 
 
 def test_connect_port_com_failure(monkeypatch):
@@ -37,3 +42,15 @@ def test_connect_port_com_failure(monkeypatch):
     assert outs == ["then"]
     assert data["serial_port"] is None
     assert data["connected"] is False
+
+
+def test_connect_port_com_disable_dtr(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    serial.QSerialPort.open_result = True
+    node = ConnectPortCom()
+    outs, data = node.on_exec(port="COM1", baud=9600, dtr=False)
+    assert outs == ["then"]
+    assert isinstance(data["serial_port"], serial.QSerialPort)
+    assert data["connected"] is True
+    assert data["serial_port"].dtr is False


### PR DESCRIPTION
## Summary
- allow `ConnectPortCom` node to toggle the DTR line via new `dtr` input
- extend serial connection tests to cover DTR state handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a3bb1a30832da7c2fc80f6710220