### PR TITLE
Enforce strict node input handling and add parse helpers

### DIFF
--- a/app/nodes/constants.py
+++ b/app/nodes/constants.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 
 @registry.register
@@ -21,12 +22,13 @@ class ConstInt(BaseNode):
         return {"value": int}
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        val = self._params.get("value", 0)
+        raw = self._params.get("value", None)
+        if raw in (None, ""):
+            return {"value": None}
         try:
-            val = int(val)
+            return {"value": int(raw)}
         except Exception:
-            val = 0
-        return {"value": val}
+            return {"value": None}
 
 
 @registry.register
@@ -47,12 +49,13 @@ class ConstFloat(BaseNode):
         return {"value": float}
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        val = self._params.get("value", 0.0)
+        raw = self._params.get("value", None)
+        if raw in (None, ""):
+            return {"value": None}
         try:
-            val = float(val)
+            return {"value": float(raw)}
         except Exception:
-            val = 0.0
-        return {"value": val}
+            return {"value": None}
 
 
 @registry.register
@@ -73,7 +76,8 @@ class ConstBool(BaseNode):
         return {"value": bool}
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        return {"value": bool(self._params.get("value", False))}
+        b = parse_bool_strict(self._params.get("value", None))
+        return {"value": b}
 
 
 @registry.register
@@ -94,4 +98,10 @@ class ConstString(BaseNode):
         return {"value": str}
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        return {"value": str(self._params.get("value", ""))}
+        raw = self._params.get("value", None)
+        if raw in (None, ""):
+            return {"value": None}
+        try:
+            return {"value": str(raw)}
+        except Exception:
+            return {"value": None}

--- a/app/nodes/control.py
+++ b/app/nodes/control.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List, Tuple
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 @registry.register
 class BeginPlay(BaseNode):
@@ -67,16 +68,21 @@ class Delay(BaseNode):
     def start(self, token_id: int, seconds=None, **_):
         from PyQt5 import QtCore
 
-        # Parse seconds robustement (accepte "1,23")
+        # valeur déjà fournie (câble) ou via in_default par le moteur
+        if seconds is None:
+            QtCore.QTimer.singleShot(
+                0,
+                lambda tid=token_id: self._scheduler.on_node_finished(self._nid, tid, ["then"], {}),
+            )
+            return
         try:
-            if seconds is None:
-                secs = 0.0
-            elif isinstance(seconds, str):
-                secs = float(seconds.replace(",", "."))
-            else:
-                secs = float(seconds)
+            secs = float(str(seconds).replace(",", "."))
         except Exception:
-            secs = 0.0
+            QtCore.QTimer.singleShot(
+                0,
+                lambda tid=token_id: self._scheduler.on_node_finished(self._nid, tid, ["then"], {}),
+            )
+            return
 
         self._current_token = token_id
         self._remaining_ms = max(0, int(secs * 1000))
@@ -131,9 +137,11 @@ class Branch(BaseNode):
     def inputs(cls):
         return {"condition": bool}
 
-    def on_exec(self, condition=False, **_):
-        port = "true" if bool(condition) else "false"
-        return ([port], {})
+    def on_exec(self, condition=None, **_):
+        b = parse_bool_strict(condition)
+        if b is None:
+            return ([], {})
+        return (["true"] if b else ["false"], {})
 
 
 @registry.register

--- a/app/nodes/convert.py
+++ b/app/nodes/convert.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 @registry.register
 class IntToString(BaseNode):
@@ -15,11 +16,12 @@ class IntToString(BaseNode):
     def outputs(cls):
         return {"text": str}
     def process(self, value=None, **_) -> Dict[str, Any]:
+        if value is None:
+            return {"text": None}
         try:
-            v = int(0 if value is None else value)
+            return {"text": str(int(value))}
         except Exception:
-            v = 0
-        return {"text": str(v)}
+            return {"text": None}
 
 @registry.register
 class FloatToString(BaseNode):
@@ -34,11 +36,12 @@ class FloatToString(BaseNode):
     def outputs(cls):
         return {"text": str}
     def process(self, value=None, **_) -> Dict[str, Any]:
+        if value is None:
+            return {"text": None}
         try:
-            v = float(0.0 if value is None else value)
+            return {"text": str(float(value))}
         except Exception:
-            v = 0.0
-        return {"text": str(v)}
+            return {"text": None}
 
 @registry.register
 class BoolToString(BaseNode):
@@ -53,4 +56,7 @@ class BoolToString(BaseNode):
     def outputs(cls):
         return {"text": str}
     def process(self, value=None, **_) -> Dict[str, Any]:
-        return {"text": "True" if bool(value) else "False"}
+        b = parse_bool_strict(value)
+        if b is None:
+            return {"text": None}
+        return {"text": "True" if b else "False"}

--- a/app/nodes/math.py
+++ b/app/nodes/math.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 @registry.register
 class ConstantNumber(BaseNode):
@@ -17,12 +18,13 @@ class ConstantNumber(BaseNode):
         return "Constant (float)"
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        v = self.params().get("value", 0.0)
+        raw = self.params().get("value", None)
+        if raw in (None, ""):
+            return {"value": None}
         try:
-            v = float(v)
+            return {"value": float(raw)}
         except Exception:
-            v = 0.0
-        return {"value": v}
+            return {"value": None}
 
 @registry.register
 class ConstantInt(BaseNode):
@@ -39,12 +41,13 @@ class ConstantInt(BaseNode):
         return "Constant (int)"
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        v = self.params().get("value", 0)
+        raw = self.params().get("value", None)
+        if raw in (None, ""):
+            return {"value": None}
         try:
-            v = int(v)
+            return {"value": int(raw)}
         except Exception:
-            v = 0
-        return {"value": v}
+            return {"value": None}
 
 @registry.register
 class ConstantBool(BaseNode):
@@ -61,8 +64,8 @@ class ConstantBool(BaseNode):
         return "Constant (bool)"
 
     def process(self, **kwargs) -> Dict[str, Any]:
-        v = self.params().get("value", False)
-        return {"value": bool(v)}
+        b = parse_bool_strict(self.params().get("value", None))
+        return {"value": b}
 
 @registry.register
 class Add(BaseNode):
@@ -79,9 +82,12 @@ class Add(BaseNode):
         return {"sum": float}
 
     def process(self, a=None, b=None, **_) -> Dict[str, Any]:
-        a = 0.0 if a is None else float(a)
-        b = 0.0 if b is None else float(b)
-        return {"sum": a + b}
+        if a is None or b is None:
+            return {"sum": None}
+        try:
+            return {"sum": float(a) + float(b)}
+        except Exception:
+            return {"sum": None}
 
 @registry.register
 class Multiply(BaseNode):
@@ -98,6 +104,9 @@ class Multiply(BaseNode):
         return {"product": float}
 
     def process(self, a=None, b=None, **_) -> Dict[str, Any]:
-        a = 0.0 if a is None else float(a)
-        b = 0.0 if b is None else float(b)
-        return {"product": a * b}
+        if a is None or b is None:
+            return {"product": None}
+        try:
+            return {"product": float(a) * float(b)}
+        except Exception:
+            return {"product": None}

--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -9,6 +9,7 @@ except Exception:
 
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 
 @registry.register
@@ -36,18 +37,32 @@ class ConnectPortCom(BaseNode):
     def on_exec(self, port=None, baud=None, dtr=None, **_):
         if not HAVE_SERIAL:
             raise RuntimeError("QtSerialPort manquant (PyQt5.QtSerialPort).")
-        port = port or self._params.get("port") or "COM3"
-        baud = baud or self._params.get("baud") or 115200
-        dtr = dtr if dtr is not None else self._params.get("dtr", True)
+
+        if port is None:
+            port = self._params.get("in_default:port", self._params.get("port"))
+        if baud is None:
+            baud = self._params.get("in_default:baud", self._params.get("baud"))
+        if dtr is None:
+            dtr = self._params.get("in_default:dtr", self._params.get("dtr"))
+
+        if port in (None, "") or baud in (None, ""):
+            return (["then"], {"serial_port": None, "connected": False})
+
         ser = QSerialPort()
         ser.setPortName(str(port))
-        ser.setBaudRate(int(baud) or 115200)
+        try:
+            ser.setBaudRate(int(baud))
+        except Exception:
+            return (["then"], {"serial_port": None, "connected": False})
+
         ok = ser.open(QSerialPort.ReadWrite)
-        if ok and dtr is not None:
-            try:
-                ser.setDataTerminalReady(bool(dtr))
-            except Exception:
-                pass
+        if ok:
+            b = parse_bool_strict(dtr)
+            if b is not None:
+                try:
+                    ser.setDataTerminalReady(b)
+                except Exception:
+                    pass
         return (["then"], {"serial_port": ser if ok else None, "connected": ok})
 
 
@@ -123,8 +138,12 @@ class SendPortComMessage(BaseNode):
 
     def on_exec(self, serial_port=None, text=None, **_):
         if HAVE_SERIAL and isinstance(serial_port, QSerialPort) and serial_port.isOpen():
+            msg = text
+            if msg is None:
+                msg = self._params.get("in_default:text", self._params.get("text"))
+            if msg in (None, ""):
+                return (["then"], {})
             try:
-                msg = text or ""
                 if not msg.endswith("\n"):
                     msg += "\n"
                 data = msg.encode("utf-8")
@@ -146,8 +165,6 @@ class OnPortComMessage(BaseNode, QtCore.QObject):
     event_node: bool = True
 
     def __init__(self, **params):
-        # default state for enabled input is True
-        params.setdefault("in_default:enabled", True)
         QtCore.QObject.__init__(self)
         BaseNode.__init__(self, **params)
         self._serial: Optional[QSerialPort] = None
@@ -250,7 +267,7 @@ class OnPortComMessage(BaseNode, QtCore.QObject):
             sched.post_ready(child)
 
     # ----- execution entry -----
-    def start(self, token_id: int, serial_port: Optional[QSerialPort] = None, enabled=True, **_):
+    def start(self, token_id: int, serial_port: Optional[QSerialPort] = None, enabled=None, **_):
         QtCore.QTimer.singleShot(
             0,
             lambda tid=token_id: self._scheduler.on_node_finished(
@@ -259,6 +276,12 @@ class OnPortComMessage(BaseNode, QtCore.QObject):
         )
         if self._active:
             self._deactivate()
+
+        if enabled is None:
+            enabled = self._params.get("in_default:enabled", self._params.get("enabled"))
+        if enabled is None:
+            return
+
         if enabled and HAVE_SERIAL and isinstance(serial_port, QSerialPort) and serial_port.isOpen():
             self._activate(serial_port)
 

--- a/app/nodes/text.py
+++ b/app/nodes/text.py
@@ -17,9 +17,9 @@ class IsEgalText(BaseNode):
         return {"equal": bool}
 
     def process(self, a=None, b=None, **_) -> Dict[str, Any]:
-        a = "" if a is None else str(a)
-        b = "" if b is None else str(b)
-        return {"equal": a == b}
+        if a is None or b is None:
+            return {"equal": None}
+        return {"equal": str(a) == str(b)}
 
 @registry.register
 class AppendText(BaseNode):
@@ -36,6 +36,6 @@ class AppendText(BaseNode):
         return {"text": str}
 
     def process(self, a=None, b=None, **_) -> Dict[str, Any]:
-        a = "" if a is None else str(a)
-        b = "" if b is None else str(b)
-        return {"text": a + b}
+        if a is None or b is None:
+            return {"text": None}
+        return {"text": str(a) + str(b)}

--- a/app/nodes/utils.py
+++ b/app/nodes/utils.py
@@ -1,0 +1,14 @@
+def parse_bool_strict(v):
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return bool(v)
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s in {"true","1","yes","y","on"}:
+            return True
+        if s in {"false","0","no","n","off"}:
+            return False
+    return None  # indéterminé

--- a/app/nodes/variables_runtime.py
+++ b/app/nodes/variables_runtime.py
@@ -2,21 +2,20 @@
 from typing import Dict, Any, List, Tuple
 from .base import BaseNode
 from ..core.registry import registry
+from .utils import parse_bool_strict
 
 _TYPE_MAP = { 'String': str, 'Int': int, 'Float': float, 'Bool': bool }
 
 def _cast(val, tname: str):
     typ = _TYPE_MAP.get(tname, str)
     if val is None:
-        return typ() if typ is not str else ''
+        return None
     if typ is bool:
-        if isinstance(val, str):
-            return val.strip().lower() in {"true", "1", "yes", "y", "on"}
-        return bool(val)
+        return parse_bool_strict(val)
     try:
         return typ(val)
     except Exception:
-        return val
+        return None
 
 @registry.register
 class GetVariable(BaseNode):
@@ -54,8 +53,16 @@ class SetVariable(BaseNode):
     def on_exec(self, **kwargs) -> Tuple[List[str], Dict[str, Any]]:
         eng = getattr(self, "_engine", None)
         if not eng: raise RuntimeError("Engine indisponible.")
-        name = self._params.get("name", "")
+        name  = self._params.get("name", "")
         tname = self._params.get("type", "String")
-        val = _cast(kwargs.get("value", None), tname)
+
+        raw = kwargs.get("value", None)
+        if raw is None:
+            raw = self._params.get("in_default:value", self._params.get("value"))
+
+        if raw is None:  # pas de câble et pas de champ -> ne rien écrire
+            return (["then"], {})
+
+        val = _cast(raw, tname)
         eng.vars[name] = val
         return (["then"], {})

--- a/tests/test_connect_port_com.py
+++ b/tests/test_connect_port_com.py
@@ -7,6 +7,7 @@ class DummySerialPort:
     ReadWrite = object()
     open_result = True
     dtr = None
+    opened = False
 
     def setPortName(self, name):
         pass
@@ -15,6 +16,7 @@ class DummySerialPort:
         pass
 
     def open(self, mode):
+        DummySerialPort.opened = True
         return self.open_result
 
     def setDataTerminalReady(self, value):
@@ -26,7 +28,7 @@ def test_connect_port_com_success(monkeypatch):
     monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
     serial.QSerialPort.open_result = True
     node = ConnectPortCom()
-    outs, data = node.on_exec(port="COM1", baud=9600)
+    outs, data = node.on_exec(port="COM1", baud=9600, dtr=True)
     assert outs == ["then"]
     assert isinstance(data["serial_port"], serial.QSerialPort)
     assert data["connected"] is True
@@ -54,3 +56,15 @@ def test_connect_port_com_disable_dtr(monkeypatch):
     assert isinstance(data["serial_port"], serial.QSerialPort)
     assert data["connected"] is True
     assert data["serial_port"].dtr is False
+
+
+def test_connect_port_com_missing_params(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    DummySerialPort.opened = False
+    node = ConnectPortCom()
+    outs, data = node.on_exec()
+    assert outs == ["then"]
+    assert data["serial_port"] is None
+    assert data["connected"] is False
+    assert DummySerialPort.opened is False

--- a/tests/test_control_nodes.py
+++ b/tests/test_control_nodes.py
@@ -1,0 +1,7 @@
+from app.nodes.control import Branch
+
+
+def test_branch_condition():
+    node = Branch()
+    assert node.on_exec(condition=None) == ([], {})
+    assert node.on_exec(condition=True) == (["true"], {})

--- a/tests/test_convert_nodes.py
+++ b/tests/test_convert_nodes.py
@@ -1,0 +1,6 @@
+from app.nodes.convert import IntToString
+
+
+def test_int_to_string_none():
+    node = IntToString()
+    assert node.process(value=None) == {"text": None}

--- a/tests/test_math_nodes.py
+++ b/tests/test_math_nodes.py
@@ -1,0 +1,7 @@
+from app.nodes.math import Add
+
+
+def test_add_with_values():
+    node = Add()
+    assert node.process(a=2, b=3) == {"sum": 5}
+    assert node.process(a=2, b=None) == {"sum": None}

--- a/tests/test_text_nodes.py
+++ b/tests/test_text_nodes.py
@@ -5,9 +5,15 @@ def test_is_egal_text():
     node = IsEgalText()
     assert node.process(a="hello", b="hello") == {"equal": True}
     assert node.process(a="hi", b="hello") == {"equal": False}
+    assert node.process(a=None, b="hello") == {"equal": None}
 
 
 def test_append_text():
     node = AppendText()
     assert node.process(a="hello", b=" world") == {"text": "hello world"}
-    assert node.process(a=None, b="foo") == {"text": "foo"}
+    assert node.process(a=None, b="foo") == {"text": None}
+
+
+def test_append_text_cable_vs_field():
+    node = AppendText(**{"in_default:a": "A"})
+    assert node.process(a=None, b="x") == {"text": None}

--- a/tests/test_variables_runtime.py
+++ b/tests/test_variables_runtime.py
@@ -1,0 +1,12 @@
+import types
+from app.nodes.variables_runtime import SetVariable
+
+
+def test_set_variable_no_value():
+    node = SetVariable(name="var", type="Int")
+    engine = types.SimpleNamespace(vars={})
+    node._engine = engine
+    outs, data = node.on_exec()
+    assert outs == ["then"]
+    assert data == {}
+    assert engine.vars == {}


### PR DESCRIPTION
## Summary
- add strict boolean parser and apply across nodes
- ensure nodes and conversions propagate `None` without defaults
- update serial, control, text, math, and variable nodes to honor cable values
- add coverage for new behaviors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b6f0e44c832d800c4225a0c0637e