### PR TITLE
Add toolbar toggle for continuous run

### DIFF
--- a/app/core/engine_async.py
+++ b/app/core/engine_async.py
@@ -34,6 +34,18 @@ class EngineRunner(QtCore.QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._scheduler: Scheduler | None = None
+        self._continuous_desired = False
+
+    def setContinuousRun(self, enabled: bool):
+        """Remember and apply the desired continuous mode.
+
+        Can be called before or during execution. If the scheduler is
+        already running the mode is applied immediately; otherwise it is
+        stored and applied when :meth:`start` is invoked.
+        """
+        self._continuous_desired = bool(enabled)
+        if self._scheduler:
+            self._scheduler.set_continuous_run(self._continuous_desired)
 
     def start(self, nodes, edges, vars_init=None):
         try:
@@ -47,6 +59,8 @@ class EngineRunner(QtCore.QObject):
             self._scheduler.on_active_tokens_changed.connect(self.sigActiveTokens)
             self._scheduler.on_reset_node_visuals.connect(self.sigResetNodeVisuals)
             self._scheduler.on_node_listening_changed.connect(self.sigNodeListening)
+            # apply user choice before the run starts
+            self._scheduler.set_continuous_run(self._continuous_desired)
             self._scheduler.setup(nodes, edges, vars_init or {})
             QtCore.QTimer.singleShot(0, self._scheduler.start_run)
         except Exception as e:  # pragma: no cover - forward error

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -112,6 +112,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.pauseAct = pauseAct
         clearAct = tb.addAction("Clear"); clearAct.triggered.connect(self.clear_graph)
         addCommentAct = tb.addAction("Commentaire"); addCommentAct.triggered.connect(self.add_comment_here)
+        tb.addSeparator()
+        self.actContinuous = tb.addAction("Exécution continue")
+        self.actContinuous.setCheckable(True)
+        self.actContinuous.setToolTip(
+            "Si activé : le graphe reste en attente (idle) et ne se termine pas automatiquement."
+        )
 
         # Context menu (right-click on view)
         self.view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
@@ -120,6 +126,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # --- EngineRunner (background execution) ---
         self.engine_runner = EngineRunner(self)
         self._hooks = MainWindow.Hooks(self)
+        self.actContinuous.toggled.connect(lambda on: self.engine_runner.setContinuousRun(on))
         self.engine_runner.sigNodeStarted.connect(self._hooks.on_node_start)
         self.engine_runner.sigNodeFinished.connect(self._hooks.on_node_finish)
         self.engine_runner.sigEdgeFired.connect(self._hooks.on_edge_fired)

--- a/tests/test_engine_runner_continuous.py
+++ b/tests/test_engine_runner_continuous.py
@@ -1,0 +1,21 @@
+from PyQt5 import QtCore
+
+from app.core.engine_async import EngineRunner
+
+
+def _app():
+    app = QtCore.QCoreApplication.instance()
+    if app is None:
+        app = QtCore.QCoreApplication([])
+    return app
+
+
+def test_engine_runner_continuous_mode_applied_before_start():
+    _app()  # ensure a Qt application exists
+    runner = EngineRunner()
+    runner.setContinuousRun(True)
+    runner.start([], [])
+    assert runner._scheduler is not None
+    assert runner._scheduler.is_continuous_run() is True
+    runner.setContinuousRun(False)
+    assert runner._scheduler.is_continuous_run() is False


### PR DESCRIPTION
## Summary
- Allow `EngineRunner` to remember continuous run preference and apply it at start
- Add "Exécution continue" toggle in main toolbar to control continuous mode
- Test continuous mode application before scheduler start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5ce070048832d92118a16f60973af