### PR TITLE
feat: add SerialPortRef variable type

### DIFF
--- a/app/nodes/variables_runtime.py
+++ b/app/nodes/variables_runtime.py
@@ -4,9 +4,16 @@ from .base import BaseNode
 from ..core.registry import registry
 from .utils import parse_bool_strict
 
+try:
+    from PyQt5.QtSerialPort import QSerialPort
+except Exception:  # pragma: no cover - optional dependency
+    QSerialPort = object
+
 _TYPE_MAP = { 'String': str, 'Int': int, 'Float': float, 'Bool': bool }
 
 def _cast(val, tname: str):
+    if tname == 'SerialPortRef':
+        return val if val is None or isinstance(val, QSerialPort) else None
     typ = _TYPE_MAP.get(tname, str)
     if val is None:
         return None

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -15,7 +15,12 @@ from ..nodes import convert as convert_nodes  # noqa: F401
 from ..nodes import variables_runtime as variable_nodes  # noqa: F401
 from ..nodes.variables_runtime import _cast as cast_var
 
-DTYPE_MAP = {'String': str, 'Int': int, 'Float': float, 'Bool': bool}
+try:
+    from PyQt5.QtSerialPort import QSerialPort
+except Exception:  # pragma: no cover - optional dependency
+    QSerialPort = object
+
+DTYPE_MAP = {'String': str, 'Int': int, 'Float': float, 'Bool': bool, 'SerialPortRef': QSerialPort}
 
 
 class FileLogger(QtWidgets.QPlainTextEdit):

--- a/app/ui/variables_panel.py
+++ b/app/ui/variables_panel.py
@@ -1,11 +1,13 @@
 
 from PyQt5 import QtWidgets, QtCore
 
-_TYPES = ['String', 'Int', 'Float', 'Bool']
+_TYPES = ['String', 'Int', 'Float', 'Bool', 'SerialPortRef']
 
 
 def _cast(val: str, tname: str) -> str:
     typemap = {'String': str, 'Int': int, 'Float': float, 'Bool': bool}
+    if tname == 'SerialPortRef':
+        return ''
     typ = typemap.get(tname, str)
     try:
         if typ is bool:

--- a/tests/test_variables_runtime.py
+++ b/tests/test_variables_runtime.py
@@ -1,5 +1,6 @@
 import types
-from app.nodes.variables_runtime import SetVariable
+import app.nodes.variables_runtime as vr
+from app.nodes.variables_runtime import SetVariable, GetVariable
 
 
 def test_set_variable_no_value():
@@ -10,3 +11,26 @@ def test_set_variable_no_value():
     assert outs == ["then"]
     assert data == {}
     assert engine.vars == {}
+
+
+def test_serial_port_ref_variable(monkeypatch):
+    class DummySerialPort:
+        pass
+
+    monkeypatch.setattr(vr, "QSerialPort", DummySerialPort)
+    dummy = DummySerialPort()
+
+    node = SetVariable(name="port", type="SerialPortRef")
+    engine = types.SimpleNamespace(vars={})
+    node._engine = engine
+    outs, data = node.on_exec(value=dummy)
+    assert outs == ["then"]
+    assert data == {}
+    assert engine.vars["port"] is dummy
+
+    get_node = GetVariable(name="port", type="SerialPortRef")
+    get_node._engine = engine
+    result = get_node.process()
+    assert result["value"] is dummy
+
+    assert vr._cast("not_a_port", "SerialPortRef") is None


### PR DESCRIPTION
## Summary
- allow variables to store serial port references
- support SerialPortRef in casting and type mapping
- test SerialPortRef get/set variable workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d6327678832dae232c74cdc76347