### PR TITLE
Add node to disconnect serial port by name

### DIFF
--- a/app/nodes/serial.py
+++ b/app/nodes/serial.py
@@ -93,6 +93,45 @@ class DisconnectPortCom(BaseNode):
 
 
 @registry.register
+class DisconnectPortComStringDebug(BaseNode):
+    @classmethod
+    def title(cls): return "Disconnect Port Com (Debug)"
+
+    @classmethod
+    def type_name(cls): return "DisconnectPortComStringDebug"
+
+    @classmethod
+    def exec_inputs(cls): return ["in"]
+
+    @classmethod
+    def exec_outputs(cls): return ["then"]
+
+    @classmethod
+    def inputs(cls): return {"port": str}
+
+    @classmethod
+    def outputs(cls): return {"disconnected": bool}
+
+    def on_exec(self, port=None, **_):
+        if not HAVE_SERIAL:
+            raise RuntimeError("QtSerialPort manquant (PyQt5.QtSerialPort).")
+        if port is None:
+            port = self._params.get("in_default:port", self._params.get("port"))
+        if port in (None, ""):
+            return (["then"], {"disconnected": False})
+        ser = QSerialPort()
+        ser.setPortName(str(port))
+        ok = False
+        try:
+            ok = ser.open(QSerialPort.ReadWrite)
+            if ok:
+                ser.close()
+        except Exception:
+            ok = False
+        return (["then"], {"disconnected": ok})
+
+
+@registry.register
 class IsValid(BaseNode):
     @classmethod
     def title(cls):

--- a/tests/test_disconnect_port_com_string_debug.py
+++ b/tests/test_disconnect_port_com_string_debug.py
@@ -1,0 +1,61 @@
+import types
+from app.nodes import serial
+from app.nodes.serial import DisconnectPortComStringDebug
+
+
+class DummySerialPort:
+    ReadWrite = object()
+    open_result = True
+    opened = False
+    closed = False
+
+    def setPortName(self, name):
+        pass
+
+    def open(self, mode):
+        DummySerialPort.opened = True
+        return self.open_result
+
+    def close(self):
+        DummySerialPort.closed = True
+
+
+def test_disconnect_port_com_string_debug_success(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    DummySerialPort.open_result = True
+    DummySerialPort.opened = False
+    DummySerialPort.closed = False
+    node = DisconnectPortComStringDebug()
+    outs, data = node.on_exec(port="COM1")
+    assert outs == ["then"]
+    assert data["disconnected"] is True
+    assert DummySerialPort.opened is True
+    assert DummySerialPort.closed is True
+
+
+def test_disconnect_port_com_string_debug_failure(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    DummySerialPort.open_result = False
+    DummySerialPort.opened = False
+    DummySerialPort.closed = False
+    node = DisconnectPortComStringDebug()
+    outs, data = node.on_exec(port="COM1")
+    assert outs == ["then"]
+    assert data["disconnected"] is False
+    assert DummySerialPort.opened is True
+    assert DummySerialPort.closed is False
+
+
+def test_disconnect_port_com_string_debug_missing_port(monkeypatch):
+    monkeypatch.setattr(serial, "HAVE_SERIAL", True)
+    monkeypatch.setattr(serial, "QSerialPort", DummySerialPort)
+    DummySerialPort.open_result = True
+    DummySerialPort.opened = False
+    DummySerialPort.closed = False
+    node = DisconnectPortComStringDebug()
+    outs, data = node.on_exec()
+    assert outs == ["then"]
+    assert data["disconnected"] is False
+    assert DummySerialPort.opened is False


### PR DESCRIPTION
## Summary
- add `DisconnectPortComStringDebug` node to release a serial port from its name
- cover new node with unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d8202514832d850b38998af67a6a