### PR TITLE
feat: enhance graph save/load

### DIFF
--- a/app/core/graph_io.py
+++ b/app/core/graph_io.py
@@ -1,36 +1,95 @@
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
-from .engine import NodeSpec, EdgeSpec
+from .engine import EdgeSpec, NodeSpec
 
 
-def save_graph(nodes: List[NodeSpec], edges: List[EdgeSpec], path: str | Path) -> None:
+def save_graph(
+    nodes: List[NodeSpec],
+    edges: List[EdgeSpec],
+    path: str | Path,
+    *,
+    variables: List[Dict[str, object]] | None = None,
+    ui: Dict[str, object] | None = None,
+) -> None:
     """Save a graph to JSON file.
 
-    Only node identifiers, their type, parameters and edge endpoints are
-    stored. It is up to the application to recreate a visual layout from
-    this information when loading.
+    Besides the basic node/edge information, optional ``variables`` and
+    ``ui`` dictionaries can be provided in order to persist editor state
+    such as node positions, edge control points or comments.
     """
-    data = {
-        "nodes": [asdict(n) for n in nodes],
-        "edges": [asdict(e) for e in edges],
+    data: Dict[str, object] = {
+        "nodes": [],
+        "edges": [],
     }
+    ui = ui or {}
+    node_ui: Dict[str, Dict[str, object]] = ui.get("nodes", {})  # type: ignore[assignment]
+    edge_ui: List[Dict[str, object]] = ui.get("edges", [])  # type: ignore[assignment]
+
+    for n in nodes:
+        nd = asdict(n)
+        if n.id in node_ui:
+            nd.update(node_ui[n.id])
+        data["nodes"].append(nd)
+
+    for i, e in enumerate(edges):
+        ed = asdict(e)
+        if i < len(edge_ui):
+            ed.update(edge_ui[i])
+        data["edges"].append(ed)
+
+    if variables:
+        data["variables"] = variables
+    if ui.get("comments"):
+        data["comments"] = ui["comments"]
+
     p = Path(path)
     with p.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
-def load_graph(path: str | Path) -> Tuple[List[NodeSpec], List[EdgeSpec]]:
+def load_graph(
+    path: str | Path,
+) -> Tuple[List[NodeSpec], List[EdgeSpec], List[Dict[str, object]], Dict[str, object]]:
     """Load a graph from a JSON file.
 
-    Returns the list of nodes and edges found in the file. Unknown keys are
-    ignored. Missing sections default to empty lists.
+    Returns the list of nodes, edges, variables and UI information found in
+    the file. Unknown keys are ignored. Missing sections default to empty
+    structures.
     """
     p = Path(path)
     with p.open("r", encoding="utf-8") as f:
         data = json.load(f)
-    nodes = [NodeSpec(**n) for n in data.get("nodes", [])]
-    edges = [EdgeSpec(**e) for e in data.get("edges", [])]
-    return nodes, edges
+
+    nodes: List[NodeSpec] = []
+    node_ui: Dict[str, Dict[str, object]] = {}
+    for nd in data.get("nodes", []):
+        pos = {k: nd.pop(k) for k in list(nd.keys()) if k not in {"id", "type_name", "params"}}
+        node = NodeSpec(id=nd.get("id"), type_name=nd.get("type_name"), params=nd.get("params", {}))
+        nodes.append(node)
+        if pos:
+            node_ui[node.id] = pos
+
+    edges: List[EdgeSpec] = []
+    edge_ui: List[Dict[str, object]] = []
+    for ed in data.get("edges", []):
+        extra = {k: ed.pop(k) for k in list(ed.keys()) if k not in {"kind", "src_id", "src_port", "dst_id", "dst_port"}}
+        edge = EdgeSpec(
+            kind=ed.get("kind"),
+            src_id=ed.get("src_id"),
+            src_port=ed.get("src_port"),
+            dst_id=ed.get("dst_id"),
+            dst_port=ed.get("dst_port"),
+        )
+        edges.append(edge)
+        edge_ui.append(extra)
+
+    variables = data.get("variables", [])
+    ui: Dict[str, object] = {
+        "nodes": node_ui,
+        "edges": edge_ui,
+        "comments": data.get("comments", []),
+    }
+    return nodes, edges, variables, ui

--- a/app/ui/graph.py
+++ b/app/ui/graph.py
@@ -711,6 +711,74 @@ class GraphScene(QtWidgets.QGraphicsScene):
             edges.append(EdgeSpec(kind=e.kind, src_id=e.src_port.parent_node.node_id, src_port=e.src_port.name, dst_id=e.dst_port.parent_node.node_id, dst_port=e.dst_port.name))
         return nodes, edges
 
+    def serialize(self) -> Tuple[List[NodeSpec], List[EdgeSpec], dict]:
+        """Return nodes, edges and UI metadata for saving."""
+        nodes, edges = self.build_specs()
+        node_ui = {}
+        for nid, item in self.nodes.items():
+            node_ui[nid] = {"pos": [item.pos().x(), item.pos().y()]}
+
+        edge_ui = []
+        for e in self.edges:
+            edge_ui.append({
+                "points": [[cp.pos().x(), cp.pos().y()] for cp in e.control_points]
+            })
+
+        comments = []
+        for c in self.comments:
+            r = c.rect
+            comments.append({
+                "rect": [r.x(), r.y(), r.width(), r.height()],
+                "color": c.color.name(),
+                "text": c.label.toPlainText(),
+            })
+
+        ui = {"nodes": node_ui, "edges": edge_ui, "comments": comments}
+        return nodes, edges, ui
+
+    def deserialize(self, nodes: List[NodeSpec], edges: List[EdgeSpec], ui: dict) -> None:
+        """Clear the scene and rebuild it from saved data."""
+        self.clear()
+        self.nodes.clear()
+        self.edges.clear()
+        self.comments.clear()
+
+        node_ui = ui.get("nodes", {})
+        for spec in nodes:
+            pos = node_ui.get(spec.id, {}).get("pos", [0, 0])
+            item = self.add_node(spec.type_name, QtCore.QPointF(*pos), params=spec.params)
+            item.setPos(QtCore.QPointF(*pos))
+
+        for idx, spec in enumerate(edges):
+            try:
+                if spec.kind == "data":
+                    src_port = self.nodes[spec.src_id].outputs[spec.src_port]
+                    dst_port = self.nodes[spec.dst_id].inputs[spec.dst_port]
+                else:
+                    src_port = self.nodes[spec.src_id].exec_outputs[spec.src_port]
+                    dst_port = self.nodes[spec.dst_id].exec_inputs[spec.dst_port]
+            except KeyError:
+                continue
+            e_item = self._finalize_edge(src_port, dst_port)
+            if e_item:
+                self.edges.append(e_item)
+                points = ui.get("edges", [])
+                if idx < len(points):
+                    for x, y in points[idx].get("points", []):
+                        cp = ControlPointItem(e_item, QtCore.QPointF(x, y))
+                        self.addItem(cp)
+                        e_item.control_points.append(cp)
+                    e_item.update_path()
+
+        for cdata in ui.get("comments", []):
+            rect = cdata.get("rect", [0, 0, 300, 200])
+            color = QtGui.QColor(cdata.get("color", "#4CAF50"))
+            comment = self.add_comment(QtCore.QPointF(rect[0], rect[1]), color)
+            comment.rect = QtCore.QRectF(*rect)
+            comment.rect_item.setRect(comment.rect)
+            comment.label.setText(cdata.get("text", ""))
+            comment._update_handles()
+
 class GraphView(QtWidgets.QGraphicsView):
     def __init__(self, scene: GraphScene):
         super().__init__(scene)

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -4,6 +4,7 @@ from typing import Optional
 from datetime import datetime
 
 from .graph import GraphScene, GraphView, NodeItem, TYPE_COLORS, CommentItem
+from ..core.graph_io import save_graph, load_graph
 from ..core.registry import registry
 from ..core.engine import ExecutionEngine
 from ..core.engine_async import EngineRunner
@@ -116,6 +117,8 @@ class MainWindow(QtWidgets.QMainWindow):
         pauseAct = tb.addAction("Pause"); pauseAct.setCheckable(True); pauseAct.triggered.connect(self.toggle_pause)
         self.pauseAct = pauseAct
         clearAct = tb.addAction("Clear"); clearAct.triggered.connect(self.clear_graph)
+        saveAct = tb.addAction("Save"); saveAct.triggered.connect(self.save_graph_to_file)
+        loadAct = tb.addAction("Load"); loadAct.triggered.connect(self.load_graph_from_file)
         addCommentAct = tb.addAction("Commentaire"); addCommentAct.triggered.connect(self.add_comment_here)
         tb.addSeparator()
         self.actContinuous = tb.addAction("Exécution continue")
@@ -224,6 +227,45 @@ class MainWindow(QtWidgets.QMainWindow):
                 from datetime import datetime
                 ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
                 self.mw.log.appendPlainText(f"[{ts}] {out['printed']}")
+
+    def save_graph_to_file(self):
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save Graph", "", "Graph (*.json)")
+        if not path:
+            return
+        nodes, edges, ui = self.scene.serialize()
+        vars_defs = [
+            {"name": n, "type": t, "init": v}
+            for n, t, v in self.varsPanel.variables()
+        ]
+        try:
+            save_graph(nodes, edges, path, variables=vars_defs, ui=ui)
+            self.log.appendPlainText(f"[INFO] Graphe sauvegardé dans {path}")
+        except Exception as e:
+            self.log.appendPlainText(f"[ERREUR] Sauvegarde: {e}")
+
+    def load_graph_from_file(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Load Graph", "", "Graph (*.json)")
+        if not path:
+            return
+        try:
+            nodes, edges, variables, ui = load_graph(path)
+            self.clear_graph()
+            self.scene.deserialize(nodes, edges, ui)
+            # Rebuild variables panel
+            self.varsPanel.table.setRowCount(0)
+            self.var_defs.clear()
+            for var in variables:
+                name = var.get("name", "")
+                tname = var.get("type", "String")
+                init = var.get("init", "")
+                self.varsPanel._add_row(name, tname, str(init))
+                self.var_defs[name] = (tname, cast_var(init, tname))
+                dtype = DTYPE_MAP.get(tname, str)
+                for item in self._iter_var_nodes(name):
+                    self._apply_variable_style(item, name, tname, dtype, error=False)
+            self.log.appendPlainText(f"[INFO] Graphe chargé depuis {path}")
+        except Exception as e:
+            self.log.appendPlainText(f"[ERREUR] Chargement: {e}")
 
     def run_graph(self):
         nodes, edges = self.scene.build_specs()

--- a/tests/test_graph_io.py
+++ b/tests/test_graph_io.py
@@ -22,12 +22,27 @@ def test_save_and_load_graph(tmp_path: Path):
         EdgeSpec(kind="data", src_id="n2", src_port="sum", dst_id="n3", dst_port="text"),
     ]
 
+    variables = [{"name": "foo", "type": "Int", "init": 0}]
+    ui = {
+        "nodes": {
+            "n1": {"pos": [10, 20]},
+            "n2": {"pos": [30, 40]},
+            "n3": {"pos": [50, 60]},
+        },
+        "edges": [{"points": []}, {"points": [[1.0, 2.0]]}],
+        "comments": [
+            {"rect": [0, 0, 100, 50], "color": "#FFFFFF", "text": "note"}
+        ],
+    }
+
     path = tmp_path / "graph.json"
-    save_graph(nodes, edges, path)
-    loaded_nodes, loaded_edges = load_graph(path)
+    save_graph(nodes, edges, path, variables=variables, ui=ui)
+    loaded_nodes, loaded_edges, loaded_vars, loaded_ui = load_graph(path)
 
     assert loaded_nodes == nodes
     assert loaded_edges == edges
+    assert loaded_vars == variables
+    assert loaded_ui == ui
 
     engine = ExecutionEngine(loaded_nodes, loaded_edges, vars_init={})
     results = engine.run()


### PR DESCRIPTION
## Summary
- persist node positions, edge control points, comments and variables when saving graphs
- add serialization helpers to GraphScene and expose Save/Load actions in UI
- extend tests to cover new graph IO data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60c99b0c4832d92036f488221a721