### PR TITLE
Handle missing type color for variable nodes

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -371,7 +371,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dtype = DTYPE_MAP.get(tname, str)
         params = {'name': name, 'type': tname, '_port_types': {'value': dtype}, 'subtitle': name}
         item = self.scene.add_node("GetVariable", pos, params=params)
-        item.header.setBrush(QtGui.QBrush(TYPE_COLORS[dtype]))
+        item.header.setBrush(QtGui.QBrush(TYPE_COLORS.get(dtype, TYPE_COLORS[object])))
         ed = item.output_editors.pop('value', None)
         if ed:
             self.scene.removeItem(ed)
@@ -381,7 +381,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dtype = DTYPE_MAP.get(tname, str)
         params = {'name': name, 'type': tname, '_port_types': {'value': dtype}, 'subtitle': name}
         item = self.scene.add_node("SetVariable", pos, params=params)
-        item.header.setBrush(QtGui.QBrush(TYPE_COLORS[dtype]))
+        item.header.setBrush(QtGui.QBrush(TYPE_COLORS.get(dtype, TYPE_COLORS[object])))
 
 
 


### PR DESCRIPTION
## Summary
- avoid KeyError when spawning Get/Set variable nodes by defaulting to generic color

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a624a063a4832d843d717ba8d6f5d6