### PR TITLE
Add scheduler continuations and ForLoop exec node

### DIFF
--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Any, Optional, Tuple, Deque
 from collections import deque, defaultdict
 from PyQt5 import QtCore
@@ -15,6 +15,9 @@ class Token:
     target: str
     data: Dict[str, Any]
     cancelled: bool = False
+    parent: Optional[int] = None
+    work: int = 0
+    cont: List[str] = field(default_factory=list)
 
 
 class Scheduler(QtCore.QObject):
@@ -181,10 +184,12 @@ class Scheduler(QtCore.QObject):
         self.on_node_listening_changed.emit(nid, bool(on))
 
     # ---- token helpers -------------------------------------------------
-    def _new_token(self, nid: str, data: Optional[Dict[str, Any]] = None) -> int:
+    def _new_token(self, nid: str, data: Optional[Dict[str, Any]] = None, parent: Optional[int] = None) -> int:
         tid = self._next_token
         self._next_token += 1
-        self.tokens[tid] = Token(tid, nid, data or {})
+        self.tokens[tid] = Token(tid, nid, data or {}, parent=parent)
+        if parent is not None and parent in self.tokens:
+            self.tokens[parent].work += 1
         self._inc_active(1)
         return tid
 
@@ -195,6 +200,13 @@ class Scheduler(QtCore.QObject):
             self._emit_state("running")
         if not self._paused:
             QtCore.QTimer.singleShot(0, self.drain)
+
+    def push_continuation(self, tid: int, nid: str) -> None:
+        tok = self.tokens.get(tid)
+        if not tok:
+            return
+        tok.cont.append(nid)
+        self._inc_active(1)
 
     # ---- running -------------------------------------------------------
     def start_run(self):
@@ -234,9 +246,10 @@ class Scheduler(QtCore.QObject):
 
     # called by nodes when finished
     def on_node_finished(self, nid: str, tid: int, next_ports: Optional[List[str]], out: Optional[Dict[str, Any]]):
+        tok = self.tokens.get(tid)
+        parent_id = tok.parent if tok else None
         node = self.nodes[nid]
         node.busy = False
-        self.tokens.pop(tid, None)
         self._inc_active(-1)
         self.on_token_finished.emit(nid, tid)
         prev = self.results.get(nid, {})
@@ -273,8 +286,31 @@ class Scheduler(QtCore.QObject):
                         self.hooks.on_edge_fired(nid, port, dst_id, dst_port)
                     except Exception:
                         pass
-                child = self._new_token(dst_id, {})
+                child = self._new_token(dst_id, {}, parent=tid)
                 self.post_ready(child)
+
+        # handle continuation for current token
+        if tok:
+            if tok.work == 0 and tok.cont:
+                cont_node = tok.cont.pop()
+                tok.target = cont_node
+                self.post_ready(tid)
+            elif tok.work == 0 and not tok.cont:
+                self.tokens.pop(tid, None)
+
+        # notify parent that this branch finished
+        if parent_id is not None:
+            parent_tok = self.tokens.get(parent_id)
+            if parent_tok:
+                parent_tok.work -= 1
+                if parent_tok.work == 0:
+                    if parent_tok.cont:
+                        cont_node = parent_tok.cont.pop()
+                        parent_tok.target = cont_node
+                        self.post_ready(parent_id)
+                    else:
+                        self.tokens.pop(parent_id, None)
+
         self._maybe_finish()
 
     # cancellation -------------------------------------------------------

--- a/app/nodes/base.py
+++ b/app/nodes/base.py
@@ -66,7 +66,7 @@ class BaseNode:
 
     # default start implementation for synchronous nodes
     def start(self, token_id: int, **kwargs) -> None:
-        outs, data = self.on_exec(**kwargs)
+        outs, data = self.on_exec(token_id=token_id, **kwargs)
         # bounce back to scheduler asynchronously to avoid re-entrancy
         QtCore.QTimer.singleShot(
             0,

--- a/app/nodes/control.py
+++ b/app/nodes/control.py
@@ -159,6 +159,52 @@ class Sequence(BaseNode):
 
 
 @registry.register
+class ForLoop(BaseNode):
+    def __init__(self, **params):
+        super().__init__(**params)
+        self._states: Dict[int, Dict[str, int]] = {}
+
+    @classmethod
+    def exec_inputs(cls):
+        return ["in"]
+
+    @classmethod
+    def exec_outputs(cls):
+        return ["loop_body", "completed"]
+
+    @classmethod
+    def inputs(cls):
+        return {"first": int, "last": int}
+
+    @classmethod
+    def outputs(cls):
+        return {"index": int}
+
+    def on_exec(self, token_id=None, first=None, last=None, **_):
+        if token_id is None:
+            return ([], {})
+        state = self._states.get(token_id)
+        if state is None:
+            if first is None or last is None:
+                return ([], {})
+            try:
+                f = int(first)
+                l = int(last)
+            except Exception:
+                return ([], {})
+            state = {"index": f, "last": l}
+            self._states[token_id] = state
+        else:
+            state["index"] += 1
+        if state["index"] <= state["last"]:
+            self._scheduler.push_continuation(token_id, self._nid)
+            return (["loop_body"], {"index": state["index"]})
+        else:
+            self._states.pop(token_id, None)
+            return (["completed"], {})
+
+
+@registry.register
 class StopExecution(BaseNode):
     """Arrête l'exécution en cours (équivaut au bouton Stop)."""
 

--- a/tests/test_control_nodes.py
+++ b/tests/test_control_nodes.py
@@ -1,7 +1,49 @@
-from app.nodes.control import Branch
+from PyQt5 import QtCore
+
+from app.nodes.control import Branch, BeginPlay, ForLoop
+from app.nodes.variables_runtime import SetVariable
+from app.core.scheduler import Scheduler
+from app.core.engine import NodeSpec, EdgeSpec
 
 
 def test_branch_condition():
     node = Branch()
     assert node.on_exec(condition=None) == ([], {})
     assert node.on_exec(condition=True) == (["true"], {})
+
+
+def _app():
+    app = QtCore.QCoreApplication.instance()
+    if app is None:
+        app = QtCore.QCoreApplication([])
+    return app
+
+
+def _run_scheduler(sched: Scheduler):
+    app = _app()
+    for _ in range(1000):
+        if sched._active_tokens == 0 and not sched._ready:
+            break
+        app.processEvents()
+
+
+def test_forloop_basic():
+    _app()
+    sched = Scheduler()
+    nodes = [
+        NodeSpec(id="begin", type_name="BeginPlay", params={}),
+        NodeSpec(id="loop", type_name="ForLoop", params={"in_default:first": 0, "in_default:last": 2}),
+        NodeSpec(id="seti", type_name="SetVariable", params={"name": "last_index", "type": "Int"}),
+        NodeSpec(id="setdone", type_name="SetVariable", params={"name": "done", "type": "Bool", "in_default:value": True}),
+    ]
+    edges = [
+        EdgeSpec(kind="exec", src_id="begin", src_port="out", dst_id="loop", dst_port="in"),
+        EdgeSpec(kind="exec", src_id="loop", src_port="loop_body", dst_id="seti", dst_port="in"),
+        EdgeSpec(kind="data", src_id="loop", src_port="index", dst_id="seti", dst_port="value"),
+        EdgeSpec(kind="exec", src_id="loop", src_port="completed", dst_id="setdone", dst_port="in"),
+    ]
+    sched.setup(nodes, edges, {})
+    sched.start_run()
+    _run_scheduler(sched)
+    assert sched.vars["last_index"] == 2
+    assert sched.vars["done"] is True


### PR DESCRIPTION
## Summary
- extend scheduler tokens with parent/work tracking and continuations
- allow BaseNode to receive token identifiers on execution
- introduce non-latent ForLoop node emitting `loop_body` per iteration and `completed` on finish
- cover ForLoop behavior with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f1cad3c8832daec58e655e1f066f