### PR TITLE
Allow editing cockpit titles with Delete key

### DIFF
--- a/app/ui/cockpit.py
+++ b/app/ui/cockpit.py
@@ -258,8 +258,15 @@ class CockpitWidget(QtWidgets.QDockWidget):
         return f"{prefix}:{i}"
 
     def eventFilter(self, obj, event):
-        if event.type() == QtCore.QEvent.KeyPress and \
-                event.key() in (QtCore.Qt.Key_Delete, QtCore.Qt.Key_Backspace):
+        if (
+            event.type() == QtCore.QEvent.KeyPress
+            and event.key() in (QtCore.Qt.Key_Delete, QtCore.Qt.Key_Backspace)
+        ):
+            # if a text-editing widget currently has focus, allow it to handle
+            # the key press so users can edit titles/fields normally
+            focus = QtWidgets.QApplication.focusWidget()
+            if isinstance(focus, (QtWidgets.QLineEdit, QtWidgets.QTextEdit)):
+                return False
             if obj is self.view or isinstance(obj, (DraggableContainer, TitleBar)):
                 self.delete_selected()
                 return True

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -56,3 +56,28 @@ def test_cockpit_delete_selected():
     if created:
         app.quit()
 
+
+def test_cockpit_title_edit_allows_deletion():
+    app, created = _setup_qt()
+    from app.ui.cockpit import CockpitWidget
+    from PyQt5 import QtCore, QtGui
+
+    c = CockpitWidget()
+    c.add_button("btn:1")
+    proxy = c._items["btn:1"]
+    container = proxy.widget()
+    title_edit = container.bar.lbl
+
+    title_edit.setText("abc")
+    title_edit.setFocus()
+
+    # send a backspace key event through the view; the title should update
+    event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, QtCore.Qt.Key_Backspace, QtCore.Qt.NoModifier)
+    QtWidgets.QApplication.sendEvent(c.view, event)
+
+    assert title_edit.text() == "ab"
+    assert "btn:1" in c._items
+
+    if created:
+        app.quit()
+


### PR DESCRIPTION
## Summary
- avoid intercepting Delete/Backspace when a text widget has focus
- test that cockpit title fields can delete text without removing items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1808b490832db880c37bf71a6da2